### PR TITLE
FISH-384: Support for Resource Servers -- Bearer authentication for JWT access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 2.0.0
 _Next release_
 
+* **BREAKING:** `OpenIdClaims` is now read-only interface with all returned claims being `Optional`.
 * Call OpenID userinfo endpoint lazily
 * Do not fail with NPE when logout is invoked on session that's not logged in via OpenID connect
 * Support Bearer Authentication for OpenID Connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 2.0.0
 _Next release_
 
+* **BREAKING:** Caller Name and Groups claims are now searched in reverse order - Access Token first, then IdentityToken and finally UserInfo claims
 * **BREAKING:** `OpenIdClaims` is now read-only interface with all returned claims being `Optional`.
 * Call OpenID userinfo endpoint lazily
 * Do not fail with NPE when logout is invoked on session that's not logged in via OpenID connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+# Version 2.0.0
+_Next release_
+
+* Support Bearer Authentication
+* Bump nimbus-jose-jwt to 9.2
+* Add standalone distribution of OpenID Connect connector. Uses different API package names
+
+
+# Version 1.1.0
+24 Jul 2020
+
+* Upgrade nimbus-jose-jwt to 8.2.1
+* Validate AccessToken expiration on each request
+* Sync API changes from upstream
+
+# Version 1.0
+25 Nov 2019
+
+* Port from [payara/payara](https://github.com/payara/payara) to standalone repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 # Version 2.0.0
 _Next release_
 
-* Support Bearer Authentication
+* Call OpenID userinfo endpoint lazily
+* Do not fail with NPE when logout is invoked on session that's not logged in via OpenID connect
+* Support Bearer Authentication for OpenID Connect
 * Bump nimbus-jose-jwt to 9.2
 * Add standalone distribution of OpenID Connect connector. Uses different API package names
 

--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -101,13 +101,12 @@
                             <shadedPattern>fish.payara.security.connectors</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern></pattern>
-                            <shadedPattern>fish.payara.security.connectors.</shadedPattern>
-                            <includes>
-                                <include>com.nimbusds.*</include>
-                                <include>org.objectweb.*</include>
-                                <include>net.jcip.*</include>
-                            </includes>
+                            <pattern>com</pattern>
+                            <shadedPattern>fish.payara.security.connectors.shaded</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net</pattern>
+                            <shadedPattern>fish.payara.security.connectors.shaded</shadedPattern>
                         </relocation>
                     </relocations>
                     <transformers>

--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -49,7 +49,7 @@
 
     <artifactId>openid-standalone</artifactId>
 
-    <licenses combine.self="append">
+    <licenses>
         <license>
             <name>CDDL + GPLv2 with classpath exception</name>
             <url>https://raw.githubusercontent.com/payara/Payara/master/LICENSE.txt</url>
@@ -74,11 +74,6 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>accessors-smart</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -112,7 +107,6 @@
                                 <include>com.nimbusds.*</include>
                                 <include>org.objectweb.*</include>
                                 <include>net.jcip.*</include>
-                                <include>net.minidev.*</include>
                             </includes>
                         </relocation>
                     </relocations>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -79,6 +79,11 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -79,10 +79,6 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>accessors-smart</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenCredential.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid;
+
+import javax.security.enterprise.credential.Credential;
+
+import fish.payara.security.openid.domain.OpenIdConfiguration;
+
+public class AccessTokenCredential implements Credential {
+    private final OpenIdConfiguration configuration;
+    private final String accessToken;
+
+    AccessTokenCredential(OpenIdConfiguration configuration, String accessToken) {
+        this.configuration = configuration;
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    OpenIdConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid;
+
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.security.enterprise.identitystore.CredentialValidationResult;
+import javax.security.enterprise.identitystore.IdentityStore;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import fish.payara.security.openid.api.AccessTokenCallerPrincipal;
+import fish.payara.security.openid.api.OpenIdConstant;
+import fish.payara.security.openid.controller.TokenClaimsSetVerifier;
+import fish.payara.security.openid.domain.AccessTokenImpl;
+import fish.payara.security.openid.domain.OpenIdConfiguration;
+import fish.payara.security.openid.domain.OpenIdContextImpl;
+
+@ApplicationScoped
+public class AccessTokenIdentityStore implements IdentityStore {
+    private static final Logger LOGGER = Logger.getLogger(AccessTokenIdentityStore.class.getName());
+
+    @Override
+    public Set<ValidationType> validationTypes() {
+        return Collections.singleton(ValidationType.VALIDATE);
+    }
+
+    @Inject
+    OpenIdContextImpl context;
+
+    @SuppressWarnings("unused")
+    public CredentialValidationResult validate(AccessTokenCredential credential) {
+        try {
+            AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(credential.getConfiguration(),
+                    credential.getAccessToken(),
+                    new BearerAuthenticator(credential.getConfiguration()));
+            context.setAccessToken(accessToken);
+            // for setClaims we'd need to invoke userinfo. That should be lazy unless required
+            // credential.getConfiguration().getClaimsConfiguration().getCallerNameClaim() might be better to use,
+            // but there's no guarantee it's present in access token, usually only sub is.
+            context.setCallerName((String) accessToken.getClaim(OpenIdConstant.SUBJECT_IDENTIFIER));
+            return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken));
+        } catch (ParseException e) {
+            LOGGER.log(Level.WARNING, "Cannot parse access token", e);
+        }
+        return CredentialValidationResult.INVALID_RESULT;
+    }
+
+    static class BearerAuthenticator extends TokenClaimsSetVerifier {
+        public BearerAuthenticator(OpenIdConfiguration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        public void verify(JWTClaimsSet claims, SecurityContext c) throws BadJWTException {
+            StandardVerifications standardVerifications = new StandardVerifications(configuration, claims);
+
+            standardVerifications.requireSameIssuer();
+            standardVerifications.requireSubject();
+            standardVerifications.requireValidTimestamp();
+            // TODO: validate audience
+        }
+
+        @Override
+        public void verify(JWTClaimsSet jwtcs) throws BadJWTException {
+
+        }
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -83,7 +83,7 @@ public class AccessTokenIdentityStore implements IdentityStore {
             // but there's no guarantee it's present in access token, usually only sub is.
             context.setCallerName((String) accessToken.getClaim(OpenIdConstant.SUBJECT_IDENTIFIER));
 
-            return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken));
+            return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken, context::getClaims));
         } catch (ParseException e) {
             LOGGER.log(Level.WARNING, "Cannot parse access token", e);
         }

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -76,12 +76,13 @@ public class AccessTokenIdentityStore implements IdentityStore {
         try {
             AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(credential.getConfiguration(),
                     credential.getAccessToken(),
-                    new BearerAuthenticator(credential.getConfiguration()));
+                    new BearerVerifier(credential.getConfiguration()));
             context.setAccessToken(accessToken);
             // for setClaims we'd need to invoke userinfo. That should be lazy unless required
             // credential.getConfiguration().getClaimsConfiguration().getCallerNameClaim() might be better to use,
             // but there's no guarantee it's present in access token, usually only sub is.
             context.setCallerName((String) accessToken.getClaim(OpenIdConstant.SUBJECT_IDENTIFIER));
+
             return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken));
         } catch (ParseException e) {
             LOGGER.log(Level.WARNING, "Cannot parse access token", e);
@@ -89,8 +90,8 @@ public class AccessTokenIdentityStore implements IdentityStore {
         return CredentialValidationResult.INVALID_RESULT;
     }
 
-    static class BearerAuthenticator extends TokenClaimsSetVerifier {
-        public BearerAuthenticator(OpenIdConfiguration configuration) {
+    static class BearerVerifier extends TokenClaimsSetVerifier {
+        public BearerVerifier(OpenIdConfiguration configuration) {
             super(configuration);
         }
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
@@ -63,7 +63,7 @@ public class OpenIdCredential implements Credential {
 
     private final OpenIdConfiguration configuration;
 
-    private final IdentityToken identityToken;
+    private final IdentityTokenImpl identityToken;
 
     private AccessToken accessToken;
 
@@ -85,6 +85,10 @@ public class OpenIdCredential implements Credential {
     }
 
     public IdentityToken getIdentityToken() {
+        return identityToken;
+    }
+
+    IdentityTokenImpl getIdentityTokenImpl() {
         return identityToken;
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -85,7 +85,7 @@ public class OpenIdIdentityStore implements IdentityStore {
     public CredentialValidationResult validate(OpenIdCredential credential) {
         HttpMessageContext httpContext = credential.getHttpContext();
         OpenIdConfiguration configuration = credential.getConfiguration();
-        IdentityTokenImpl idToken = (IdentityTokenImpl) credential.getIdentityToken();
+        IdentityTokenImpl idToken = credential.getIdentityTokenImpl();
         
         Algorithm idTokenAlgorithm = idToken.getTokenJWT().getHeader().getAlgorithm();
         

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -103,12 +103,9 @@ public class OpenIdIdentityStore implements IdentityStore {
 
         AccessTokenImpl accessToken = (AccessTokenImpl) credential.getAccessToken();
         if (nonNull(accessToken)) {
-            Map<String, Object> accesTokenClaims = tokenController.validateAccessToken(
+            tokenController.validateAccessToken(
                     accessToken, idTokenAlgorithm, context.getIdentityToken().getClaims(), configuration
             );
-            if (accessToken.isEncrypted()) {
-                accessToken.setClaims(accesTokenClaims);
-            }
             context.setAccessToken(accessToken);
             JsonObject userInfo = userInfoController.getUserInfo(configuration, accessToken);
             context.setClaims(userInfo);

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -45,6 +45,7 @@ import fish.payara.security.openid.domain.IdentityTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdContextImpl;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -60,8 +61,6 @@ import javax.json.JsonValue;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
-
-import net.minidev.json.JSONArray;
 
 /**
  * Identity store validates the identity token & access toekn and returns the
@@ -82,6 +81,7 @@ public class OpenIdIdentityStore implements IdentityStore {
     @Inject
     private UserInfoController userInfoController;
 
+    @SuppressWarnings("unused") // IdentityStore calls overloads
     public CredentialValidationResult validate(OpenIdCredential credential) {
         HttpMessageContext httpContext = credential.getHttpContext();
         OpenIdConfiguration configuration = credential.getConfiguration();
@@ -143,10 +143,12 @@ public class OpenIdIdentityStore implements IdentityStore {
         String callerGroupsClaim = configuration.getClaimsConfiguration().getCallerGroupsClaim();
         JsonArray groupsUserinfoClaim
                 = context.getClaimsJson().getJsonArray(callerGroupsClaim);
-        JSONArray groupsIdentityClaim
-                = (JSONArray) context.getIdentityToken().getClaim(callerGroupsClaim);
-        JSONArray groupsAccessClaim
-                = (JSONArray) context.getAccessToken().getClaim(callerGroupsClaim);
+        @SuppressWarnings("unchecked")
+        List<Object> groupsIdentityClaim
+                = (List<Object>) context.getIdentityToken().getClaim(callerGroupsClaim);
+        @SuppressWarnings("unchecked")
+        List<Object> groupsAccessClaim
+                = (List<Object>) context.getAccessToken().getClaim(callerGroupsClaim);
         if (nonNull(groupsUserinfoClaim)) {
             for (int i = 0; i < groupsUserinfoClaim.size(); i++) {
                 JsonValue value = groupsUserinfoClaim.get(i);

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -107,8 +107,6 @@ public class OpenIdIdentityStore implements IdentityStore {
                     accessToken, idTokenAlgorithm, context.getIdentityToken().getClaims(), configuration
             );
             context.setAccessToken(accessToken);
-            JsonObject userInfo = userInfoController.getUserInfo(configuration, accessToken);
-            context.setClaims(userInfo);
         }
 
         context.setCallerName(getCallerName(configuration));

--- a/openid/src/main/java/fish/payara/security/openid/api/AccessToken.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/AccessToken.java
@@ -38,6 +38,7 @@
 package fish.payara.security.openid.api;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The Access Token is used by an application to access protected resources.
@@ -52,22 +53,38 @@ public interface AccessToken {
     public String getToken();
 
     /**
+     * Signify, if access token is JWT based, or opaque.
+     * @return true if access token is JWT token.
+     */
+    boolean isJWT();
+
+    /**
+     * Access token's claims
+     * @return access token claims if it is a JWT Token, {@link JwtClaims#NONE} otherwise.
+     */
+    JwtClaims getJwtClaims();
+
+    /**
      * @return the access token's claims that was received from the OpenId Connect
      * provider
+     * @deprecated in favor of {@link #getJwtClaims()}
      */
+    @Deprecated
     Map<String, Object> getClaims();
 
     /**
      * @param key the claim key
-     * @return the identity token's claim based on requested key type.
+     * @return the identity token's claim based on requested key type or null if not provided
+     * @deprecated in favor of {@link #getJwtClaims()}
      */
+    @Deprecated
     Object getClaim(String key);
 
     /**
      * Optional. Expiration time of the Access Token in seconds since the
      * response was generated.
      *
-     * @return the expiration time of the Access Token
+     * @return the expiration time of the Access Token or null if expiration time is not known
      */
     Long getExpirationTime();
 

--- a/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
@@ -42,6 +42,10 @@ import javax.security.enterprise.CallerPrincipal;
 
 import fish.payara.security.openid.api.AccessToken;
 
+/**
+ * Principal representing JWT Access token passed via HTTP Header {@code Authentication: Bearer}.
+ *
+ */
 public class AccessTokenCallerPrincipal extends CallerPrincipal {
     private final AccessToken accessToken;
 
@@ -50,7 +54,28 @@ public class AccessTokenCallerPrincipal extends CallerPrincipal {
         this.accessToken = token;
     }
 
+    /**
+     * Underyling access token.
+     * @return
+     */
     public AccessToken getAccessToken() {
         return accessToken;
+    }
+
+    /**
+     * JWT Claims of access token
+     * @return
+     */
+    public JwtClaims getClaims() {
+        return accessToken.getJwtClaims();
+    }
+
+    /**
+     * Check whether specific audience string is present in the token
+     * @param audience audience to look for
+     * @return true if audience is present in access token's JWT claims
+     */
+    public boolean hasAudience(String audience) {
+        return getClaims().getAudience().contains(audience);
     }
 }

--- a/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.api;
+
+import javax.security.enterprise.CallerPrincipal;
+
+import fish.payara.security.openid.api.AccessToken;
+
+public class AccessTokenCallerPrincipal extends CallerPrincipal {
+    private final AccessToken accessToken;
+
+    public AccessTokenCallerPrincipal(AccessToken token) {
+        super((String) token.getClaim("sub"));
+        this.accessToken = token;
+    }
+
+    public AccessToken getAccessToken() {
+        return accessToken;
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCallerPrincipal.java
@@ -38,6 +38,8 @@
 
 package fish.payara.security.openid.api;
 
+import java.util.function.Supplier;
+
 import javax.security.enterprise.CallerPrincipal;
 
 import fish.payara.security.openid.api.AccessToken;
@@ -48,10 +50,12 @@ import fish.payara.security.openid.api.AccessToken;
  */
 public class AccessTokenCallerPrincipal extends CallerPrincipal {
     private final AccessToken accessToken;
+    private final Supplier<OpenIdClaims> userInfoSupplier;
 
-    public AccessTokenCallerPrincipal(AccessToken token) {
+    public AccessTokenCallerPrincipal(AccessToken token, Supplier<OpenIdClaims> userInfoSupplier) {
         super((String) token.getClaim("sub"));
         this.accessToken = token;
+        this.userInfoSupplier = userInfoSupplier;
     }
 
     /**
@@ -77,5 +81,14 @@ public class AccessTokenCallerPrincipal extends CallerPrincipal {
      */
     public boolean hasAudience(String audience) {
         return getClaims().getAudience().contains(audience);
+    }
+
+    /**
+     * Claims returned by userinfo endpoint. First call to this method will invoke userinfo endpoint of the provider
+     * to fetch the data
+     * @return user's identity claims.
+     */
+    public OpenIdClaims getUserInfoClaims() {
+        return userInfoSupplier.get();
     }
 }

--- a/openid/src/main/java/fish/payara/security/openid/api/BearerGroupsIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/BearerGroupsIdentityStore.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.api;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.security.enterprise.identitystore.CredentialValidationResult;
+import javax.security.enterprise.identitystore.IdentityStore;
+
+public abstract class BearerGroupsIdentityStore implements IdentityStore {
+    @Override
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
+        if (validationResult.getCallerPrincipal() instanceof AccessTokenCallerPrincipal) {
+            return getCallerGroups((AccessTokenCallerPrincipal)validationResult.getCallerPrincipal());
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    protected abstract Set<String> getCallerGroups(AccessTokenCallerPrincipal callerPrincipal);
+
+    @Override
+    public Set<ValidationType> validationTypes() {
+        return Collections.singleton(ValidationType.PROVIDE_GROUPS);
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/api/Claims.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/Claims.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+public interface Claims {
+    /**
+     * Get String claim of given name
+     *
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a string
+     */
+    Optional<String> getStringClaim(String name);
+
+    /**
+     * Get Numeric Date claim of given name
+     *
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number that represents an epoch seconds
+     */
+    Optional<Instant> getNumericDateClaim(String name);
+
+    /**
+     * Get String List claim of given name
+     *
+     * @param name
+     * @return a list with values of the claim, or empty list if value is not present.
+     * @throws IllegalArgumentException when value of claim is neither string or array of strings
+     */
+    List<String> getArrayStringClaim(String name);
+
+    /**
+     * Get integer claim of given name
+     *
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalInt getIntClaim(String name);
+
+    /**
+     * Get long claim of given name
+     *
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalLong getLongClaim(String name);
+
+    /**
+     * Get double claim of given name
+     *
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalDouble getDoubleClaim(String name);
+
+    /**
+     * Get nested claims of given name.
+     * @param name
+     * @return Claims instance represented nested values within that claim, or empty optional if not present
+     * @throws IllegalArgumentException when value is not a nested object
+     */
+    Optional<Claims> getNested(String name);
+}

--- a/openid/src/main/java/fish/payara/security/openid/api/IdentityToken.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/IdentityToken.java
@@ -50,19 +50,29 @@ public interface IdentityToken {
     /**
      * @return the identity token
      */
-    public String getToken();
+    String getToken();
 
     /**
      * @return the identity token's claims that was received from the OpenId
      * Connect provider
+     * @deprecated use {@link #getJwtClaims()}
      */
+    @Deprecated
     Map<String, Object> getClaims();
 
     /**
      * @param key the claim key
      * @return the identity token's claim based on requested key type.
+     * @deprecated use {@link #getJwtClaims()}
      */
+    @Deprecated
     Object getClaim(String key);
+
+    /**
+     * Claims of this token
+     * @return claims of this token
+     */
+    JwtClaims getJwtClaims();
 
     /**
      * Checks if the Identity Token is expired.

--- a/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
@@ -44,6 +44,9 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 
 /**
@@ -104,7 +107,7 @@ public interface JwtClaims {
      * @return
      */
     default Optional<Instant> getNotBeforeTime() {
-        return getNumericDateClaim("iat");
+        return getNumericDateClaim("nbf");
     }
 
     /**
@@ -169,6 +172,30 @@ public interface JwtClaims {
     List<String> getArrayStringClaim(String name);
 
     /**
+     * Get integer claim of given name
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalInt getIntClaim(String name);
+
+    /**
+     * Get long claim of given name
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalLong getLongClaim(String name);
+
+    /**
+     * Get double claim of given name
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number
+     */
+    OptionalDouble getDoubleClaim(String name);
+
+    /**
      * Singleton instance representing no claims
      */
     JwtClaims NONE = new JwtClaims() {
@@ -185,6 +212,21 @@ public interface JwtClaims {
         @Override
         public List<String> getArrayStringClaim(String name) {
             return Collections.emptyList();
+        }
+
+        @Override
+        public OptionalInt getIntClaim(String name) {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public OptionalLong getLongClaim(String name) {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public OptionalDouble getDoubleClaim(String name) {
+            return OptionalDouble.empty();
         }
     };
 }

--- a/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.api;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Standard JWT claims. A token typically
+ *
+ *
+ */
+public interface JwtClaims {
+    /**
+     * The principal that issued the JWT
+     * @return value of {@code iss} claim
+     */
+    default Optional<String> getIssuer() {
+        return getStringClaim("iss");
+    }
+
+    /**
+     * The principal that is the
+     *    subject of the JWT.  The claims in a JWT are normally statements
+     *    about the subject.
+     * @return value of {@code sub} claim
+     */
+    default Optional<String> getSubject() {
+        return getStringClaim("sub");
+    }
+
+    /**
+     * The recipients that the JWT is intended for. To ease work with the field, audience is always represented as list,
+     * also in special cases -- it is singleton list when it was a string in the token, and empty set if it was not present.
+     * @return non-null set representing the values of {@code aud} claim
+     */
+    default List<String> getAudience() {
+        return getArrayStringClaim("aud");
+    }
+
+    /**
+     * Expiration time on or after which the JWT MUST NOT be accepted for processing.
+     * @return value of {@code exp} claim
+     */
+    default Optional<Instant> getExpirationTime() {
+        return getNumericDateClaim("exp");
+    }
+
+    /**
+     * Check if JWT is expired
+     * @param clock Clock representing reference time of checking
+     * @param required indication whether the claim is required, i. e. whether token with claim is considered expired
+     * @param skew allowed clock skew to account for drift between provider and us
+     * @return {@code} true when current time is past expiration time, or {@code exp} claim is not present and {@code required} is {@code true}
+     */
+    default boolean isExpired(Clock clock, boolean required, Duration skew) {
+        return getExpirationTime().map(exp -> clock.millis() - exp.toEpochMilli() > skew.toMillis())
+                .orElse(required);
+    }
+
+    /**
+     * The time before which the JWT MUST NOT be accepted for processing.
+     * @return
+     */
+    default Optional<Instant> getNotBeforeTime() {
+        return getNumericDateClaim("iat");
+    }
+
+    /**
+     * Check if JWT is before its defined validity
+     * @param clock Clock representing reference time of checking
+     * @param required indication, whether the claim is required, i. e. whether token without nbf is considered before validity
+     * @param skew allowed clock skew to account for drift between provider and us
+     * @return
+     */
+    default boolean isBeforeValidity(Clock clock, boolean required, Duration skew) {
+        return getNotBeforeTime().map(nbf -> nbf.toEpochMilli() - clock.millis() > skew.toMillis())
+                .orElse(required);
+    }
+
+    /**
+     * Check JWT validity against current time with 1MIN clock skew.
+     * @return true if exp token is present and within limits and nbf is within limits when present
+     */
+    default boolean isValid() {
+        Duration skew = Duration.ofMinutes(1);
+        return !isExpired(Clock.systemUTC(), true, skew) && !isBeforeValidity(Clock.systemUTC(), false, skew);
+    }
+
+    /**
+     * The time at which the JWT was issued.
+     * @return value of {@code exp} claim
+     */
+    default Optional<Instant> getIssuedAt() {
+        return getNumericDateClaim("iat");
+    }
+
+    /**
+     * Unique identifier for the JWT
+     * @return value of {@code jti} claim
+     */
+    default Optional<String> getJwtId() {
+        return getStringClaim("jti");
+    }
+
+    /**
+     * Get String claim of given name
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a string
+     */
+    Optional<String> getStringClaim(String name);
+
+    /**
+     * Get Numeric Date claim of given name
+     * @param name
+     * @return value, or empty optional if not present
+     * @throws IllegalArgumentException when value of claim is not a number that represents an epoch seconds
+     */
+    Optional<Instant> getNumericDateClaim(String name);
+
+    /**
+     * Get String List claim of given name
+     * @param name
+     * @return a list with values of the claim, or empty list if value is not present.
+     * @throws IllegalArgumentException when value of claim is neither string or array of strings
+     */
+    List<String> getArrayStringClaim(String name);
+
+    /**
+     * Singleton instance representing no claims
+     */
+    JwtClaims NONE = new JwtClaims() {
+        @Override
+        public Optional<String> getStringClaim(String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Instant> getNumericDateClaim(String name) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<String> getArrayStringClaim(String name) {
+            return Collections.emptyList();
+        }
+    };
+}

--- a/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/JwtClaims.java
@@ -54,7 +54,7 @@ import java.util.Set;
  *
  *
  */
-public interface JwtClaims {
+public interface JwtClaims extends Claims {
     /**
      * The principal that issued the JWT
      * @return value of {@code iss} claim
@@ -148,54 +148,6 @@ public interface JwtClaims {
     }
 
     /**
-     * Get String claim of given name
-     * @param name
-     * @return value, or empty optional if not present
-     * @throws IllegalArgumentException when value of claim is not a string
-     */
-    Optional<String> getStringClaim(String name);
-
-    /**
-     * Get Numeric Date claim of given name
-     * @param name
-     * @return value, or empty optional if not present
-     * @throws IllegalArgumentException when value of claim is not a number that represents an epoch seconds
-     */
-    Optional<Instant> getNumericDateClaim(String name);
-
-    /**
-     * Get String List claim of given name
-     * @param name
-     * @return a list with values of the claim, or empty list if value is not present.
-     * @throws IllegalArgumentException when value of claim is neither string or array of strings
-     */
-    List<String> getArrayStringClaim(String name);
-
-    /**
-     * Get integer claim of given name
-     * @param name
-     * @return value, or empty optional if not present
-     * @throws IllegalArgumentException when value of claim is not a number
-     */
-    OptionalInt getIntClaim(String name);
-
-    /**
-     * Get long claim of given name
-     * @param name
-     * @return value, or empty optional if not present
-     * @throws IllegalArgumentException when value of claim is not a number
-     */
-    OptionalLong getLongClaim(String name);
-
-    /**
-     * Get double claim of given name
-     * @param name
-     * @return value, or empty optional if not present
-     * @throws IllegalArgumentException when value of claim is not a number
-     */
-    OptionalDouble getDoubleClaim(String name);
-
-    /**
      * Singleton instance representing no claims
      */
     JwtClaims NONE = new JwtClaims() {
@@ -227,6 +179,11 @@ public interface JwtClaims {
         @Override
         public OptionalDouble getDoubleClaim(String name) {
             return OptionalDouble.empty();
+        }
+
+        @Override
+        public Optional<Claims> getNested(String name) {
+            return Optional.empty();
         }
     };
 }

--- a/openid/src/main/java/fish/payara/security/openid/api/OpenIdClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/OpenIdClaims.java
@@ -37,259 +37,98 @@
  */
 package fish.payara.security.openid.api;
 
-import static fish.payara.security.openid.api.OpenIdConstant.ADDRESS;
-import static fish.payara.security.openid.api.OpenIdConstant.BIRTHDATE;
-import static fish.payara.security.openid.api.OpenIdConstant.EMAIL;
-import static fish.payara.security.openid.api.OpenIdConstant.EMAIL_VERIFIED;
-import static fish.payara.security.openid.api.OpenIdConstant.FAMILY_NAME;
-import static fish.payara.security.openid.api.OpenIdConstant.GENDER;
-import static fish.payara.security.openid.api.OpenIdConstant.GIVEN_NAME;
-import static fish.payara.security.openid.api.OpenIdConstant.LOCALE;
-import static fish.payara.security.openid.api.OpenIdConstant.MIDDLE_NAME;
-import static fish.payara.security.openid.api.OpenIdConstant.NAME;
-import static fish.payara.security.openid.api.OpenIdConstant.NICKNAME;
-import static fish.payara.security.openid.api.OpenIdConstant.PHONE_NUMBER;
-import static fish.payara.security.openid.api.OpenIdConstant.PHONE_NUMBER_VERIFIED;
-import static fish.payara.security.openid.api.OpenIdConstant.PICTURE;
-import static fish.payara.security.openid.api.OpenIdConstant.PREFERRED_USERNAME;
-import static fish.payara.security.openid.api.OpenIdConstant.PROFILE;
-import static fish.payara.security.openid.api.OpenIdConstant.UPDATED_AT;
-import static fish.payara.security.openid.api.OpenIdConstant.WEBSITE;
-import static fish.payara.security.openid.api.OpenIdConstant.ZONEINFO;
+import java.util.Optional;
+
 import javax.json.JsonObject;
+
+import static fish.payara.security.openid.api.OpenIdConstant.*;
 
 /**
  * User Claims received from the userinfo endpoint
  *
  * @author Gaurav Gupta
  */
-public class OpenIdClaims {
+public interface OpenIdClaims extends Claims {
 
-    // profile scope claims
-    private String name;
-    private String familyName;
-    private String givenName;
-    private String middleName;
-    private String nickname;
-    private String preferredUsername;
-    private String profile;
-    private String picture;
-    private String website;
-    private String gender;
-    private String birthdate;
-    private String zoneinfo;
-    private String locale;
-    private String updatedAt;
-
-    // email scope claims
-    private String email;
-    private String emailVerified;
-
-    // address scope claims
-    private String address;
-
-    // phone scope claims
-    private String phoneNumber;
-    private String phoneNumberVerified;
-
-    public OpenIdClaims(JsonObject claims) {
-        this.name = claims.getString(NAME, null);
-        this.familyName = claims.getString(FAMILY_NAME, null);
-        this.givenName = claims.getString(GIVEN_NAME, null);
-        this.middleName = claims.getString(MIDDLE_NAME, null);
-        this.nickname = claims.getString(NICKNAME, null);
-        this.preferredUsername = claims.getString(PREFERRED_USERNAME, null);
-        this.profile = claims.getString(PROFILE, null);
-        this.picture = claims.getString(PICTURE, null);
-        this.website = claims.getString(WEBSITE, null);
-        this.gender = claims.getString(GENDER, null);
-        this.birthdate = claims.getString(BIRTHDATE, null);
-        this.zoneinfo = claims.getString(ZONEINFO, null);
-        this.locale = claims.getString(LOCALE, null);
-        this.updatedAt = claims.getString(UPDATED_AT, null);
-        this.email = claims.getString(EMAIL, null);
-        this.emailVerified = claims.getString(EMAIL_VERIFIED, null);
-        this.address = claims.getString(ADDRESS, null);
-        this.phoneNumber = claims.getString(PHONE_NUMBER, null);
-        this.phoneNumberVerified = claims.getString(PHONE_NUMBER_VERIFIED, null);
+    default String getSubject() {
+        return getStringClaim(SUBJECT_IDENTIFIER).orElseThrow(() -> new IllegalArgumentException("Payload does not represent correct UserInfo response"));
     }
 
-    public String getName() {
-        return name;
+    default Optional<String> getName() {
+        return getStringClaim(NAME);
     }
 
-    public void setName(String name) {
-        this.name = name;
+    default Optional<String> getFamilyName() {
+        return getStringClaim(FAMILY_NAME);
     }
 
-    public String getFamilyName() {
-        return familyName;
+    default Optional<String> getGivenName() {
+        return getStringClaim(GIVEN_NAME);
     }
 
-    public void setFamilyName(String familyName) {
-        this.familyName = familyName;
+    default Optional<String> getMiddleName() {
+        return getStringClaim(MIDDLE_NAME);
     }
 
-    public String getGivenName() {
-        return givenName;
+    default Optional<String> getNickname() {
+        return getStringClaim(NICKNAME);
     }
 
-    public void setGivenName(String givenName) {
-        this.givenName = givenName;
+    default Optional<String> getPreferredUsername() {
+        return getStringClaim(PREFERRED_USERNAME);
     }
 
-    public String getMiddleName() {
-        return middleName;
+    default Optional<String> getProfile() {
+        return getStringClaim(PROFILE);
     }
 
-    public void setMiddleName(String middleName) {
-        this.middleName = middleName;
+    default Optional<String> getPicture() {
+        return getStringClaim(PICTURE);
     }
 
-    public String getNickname() {
-        return nickname;
+    default Optional<String> getGender() {
+        return getStringClaim(GENDER);
     }
 
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
+    default Optional<String> getBirthdate() {
+        return getStringClaim(BIRTHDATE);
     }
 
-    public String getPreferredUsername() {
-        return preferredUsername;
+    default Optional<String> getZoneinfo() {
+        return getStringClaim(ZONEINFO);
     }
 
-    public void setPreferredUsername(String preferredUsername) {
-        this.preferredUsername = preferredUsername;
+    default Optional<String> getLocale() {
+        return getStringClaim(LOCALE);
     }
 
-    public String getProfile() {
-        return profile;
+    default Optional<String> getUpdatedAt() {
+        return getStringClaim(UPDATED_AT);
     }
 
-    public void setProfile(String profile) {
-        this.profile = profile;
+    default Optional<String> getEmail() {
+        return getStringClaim(EMAIL);
     }
 
-    public String getPicture() {
-        return picture;
+    default Optional<String> getEmailVerified() {
+        return getStringClaim(EMAIL_VERIFIED);
     }
 
-    public void setPicture(String picture) {
-        this.picture = picture;
+    default Optional<String> getAddress() {
+        return getStringClaim(ADDRESS);
     }
 
-    public String getWebsite() {
-        return website;
+    default Optional<String> getPhoneNumber() {
+        return getStringClaim(PHONE_NUMBER);
     }
 
-    public void setWebsite(String website) {
-        this.website = website;
+    default Optional<String> getPhoneNumberVerified() {
+        return getStringClaim(PHONE_NUMBER_VERIFIED);
     }
 
-    public String getGender() {
-        return gender;
+    default Optional<String> getWebsite() {
+        return getStringClaim(WEBSITE);
     }
 
-    public void setGender(String gender) {
-        this.gender = gender;
-    }
-
-    public String getBirthdate() {
-        return birthdate;
-    }
-
-    public void setBirthdate(String birthdate) {
-        this.birthdate = birthdate;
-    }
-
-    public String getZoneinfo() {
-        return zoneinfo;
-    }
-
-    public void setZoneinfo(String zoneinfo) {
-        this.zoneinfo = zoneinfo;
-    }
-
-    public String getLocale() {
-        return locale;
-    }
-
-    public void setLocale(String locale) {
-        this.locale = locale;
-    }
-
-    public String getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(String updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getEmailVerified() {
-        return emailVerified;
-    }
-
-    public void setEmailVerified(String emailVerified) {
-        this.emailVerified = emailVerified;
-    }
-
-    public String getAddress() {
-        return address;
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public void setPhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
-
-    public String getPhoneNumberVerified() {
-        return phoneNumberVerified;
-    }
-
-    public void setPhoneNumberVerified(String phoneNumberVerified) {
-        this.phoneNumberVerified = phoneNumberVerified;
-    }
-
-    @Override
-    public String toString() {
-        return OpenIdClaims.class.getSimpleName()
-                + "{"
-                + "name=" + name
-                + ", familyName=" + familyName
-                + ", givenName=" + givenName
-                + ", middleName=" + middleName
-                + ", nickname=" + nickname
-                + ", preferredUsername=" + preferredUsername
-                + ", profile=" + profile
-                + ", picture=" + picture
-                + ", website=" + website
-                + ", gender=" + gender
-                + ", birthdate=" + birthdate
-                + ", zoneinfo=" + zoneinfo
-                + ", locale=" + locale
-                + ", updatedAt=" + updatedAt
-                + ", email=" + email
-                + ", emailVerified=" + emailVerified
-                + ", address=" + address
-                + ", phoneNumber=" + phoneNumber
-                + ", phoneNumberVerified=" + phoneNumberVerified
-                + '}';
-    }
 
 }

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
@@ -46,12 +46,15 @@ import fish.payara.security.openid.api.OpenIdConstant;
 
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
  *
  * @author Gaurav Gupta
+ * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation">OpenID Connect core 1.0, section 3.1.3.7</a>
  */
 public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
 
@@ -61,87 +64,114 @@ public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
         this.configuration = configuration;
     }
 
-    @Override
-    public void verify(JWTClaimsSet claims, SecurityContext c) throws BadJWTException {
+    protected static class StandardVerifications {
+        private final OpenIdConfiguration configuration;
+        private final JWTClaimsSet claims;
 
-        int clockSkewInSeconds = 60;
-        int clockSkewInMillis = clockSkewInSeconds * 1000;
+        protected StandardVerifications(OpenIdConfiguration configuration, JWTClaimsSet claims) {
+            this.configuration = configuration;
+            this.claims = claims;
+        }
 
         /**
          * The Issuer Identifier for the OpenID Provider (which is typically
          * obtained during Discovery) must exactly match the value of the iss
          * (issuer) Claim.
          */
-        if (isNull(claims.getIssuer())) {
-            throw new IllegalStateException("Missing issuer (iss) claim");
-        }
-        if (!claims.getIssuer().equals(configuration.getProviderMetadata().getIssuerURI())) {
-            throw new IllegalStateException("Invalid issuer : " + configuration.getProviderMetadata().getIssuerURI());
+        public void requireSameIssuer() {
+            if (isNull(claims.getIssuer())) {
+                throw new IllegalStateException("Missing issuer (iss) claim");
+            }
+            if (!claims.getIssuer().equals(configuration.getProviderMetadata().getIssuerURI())) {
+                throw new IllegalStateException("Invalid issuer : " + configuration.getProviderMetadata().getIssuerURI());
+            }
         }
 
         /**
          * Subject Identifier is locally unique and never reassigned identifier
          * within the Issuer for the End-User.
          */
-        if (isNull(claims.getSubject())) {
-            throw new IllegalStateException("Missing subject (sub) claim");
+        public void requireSubject() {
+            if (isNull(claims.getSubject())) {
+                throw new IllegalStateException("Missing subject (sub) claim");
+            }
+
         }
 
         /**
          * Audience(s) claim (that this ID Token is intended for) must contains
          * the client_id of the Client (Relying Party) as an audience value.
+         *
+         * Other use cases may allow different audience than client Id, but generally require one.
          */
-        final List<String> audience = claims.getAudience();
-        if (isNull(audience) || audience.isEmpty()) {
-            throw new IllegalStateException("Missing audience (aud) claim");
+        public void requireAudience(String requiredAudience) {
+            final List<String> audience = claims.getAudience();
+            if (isNull(audience) || audience.isEmpty()) {
+                throw new IllegalStateException("Missing audience (aud) claim");
+            }
+            if (requiredAudience != null && !audience.contains(requiredAudience)) {
+                throw new IllegalStateException("Invalid audience (aud) claim " + audience);
+            }
         }
-        if (!audience.contains(configuration.getClientId())) {
-            throw new IllegalStateException("Invalid audience (aud) claim " + audience);
-        }
+
 
         /**
          * If the ID Token contains multiple audiences, the Client should verify
          * that an azp (authorized party) claim is present.
-         */
-        Object authorizedParty = claims.getClaim(OpenIdConstant.AUTHORIZED_PARTY);
-        if (audience.size() > 1 && isNull(authorizedParty)) {
-            throw new IllegalStateException("Missing authorized party (azp) claim");
-        }
-
-        /**
+         *
          * If an azp (authorized party) claim is present, the Client should
          * verify that its client_id is the claim Value
          */
-        if (audience.size() > 1
-                && nonNull(authorizedParty)
-                && !authorizedParty.equals(configuration.getClientId())) {
-            throw new IllegalStateException("Invalid authorized party (azp) claim " + configuration.getClientId());
+        public void assureAuthorizedParty(String clientId) {
+            Object authorizedParty = claims.getClaim(OpenIdConstant.AUTHORIZED_PARTY);
+            List<String> audience = claims.getAudience();
+            if (audience.size() > 1 && isNull(authorizedParty)) {
+                throw new IllegalStateException("Missing authorized party (azp) claim");
+            }
+
+            if (audience.size() > 1
+                    && nonNull(authorizedParty)
+                    && !authorizedParty.equals(clientId)) {
+                throw new IllegalStateException("Invalid authorized party (azp) claim " + authorizedParty);
+            }
         }
 
         /**
          * The current time must be before the time represented by the exp
          * Claim.
-         */
-        long currentTime = System.currentTimeMillis();
-        Date exp = claims.getExpirationTime();
-        if (isNull(exp)) {
-            throw new IllegalStateException("Missing expiration time (exp) claim");
-        }
-        if ((exp.getTime() + clockSkewInMillis) < currentTime) {
-            throw new IllegalStateException("Token is expired " + exp);
-        }
-
-        /**
+         *
          * The current time must be after the time represented by the iat Claim.
          */
-        Date iat = claims.getIssueTime();
-        if (isNull(iat)) {
-            throw new IllegalStateException("Missing issue time (iat) claim");
-        }
-        if ((iat.getTime() - clockSkewInMillis) > currentTime) {
-            throw new IllegalStateException("Issue time must be after current time " + iat);
-        }
+        public void requireValidTimestamp() {
+            long clockSkewInMillis = TimeUnit.MINUTES.toMillis(1);
+            long currentTime = System.currentTimeMillis();
+            Date exp = claims.getExpirationTime();
+            if (isNull(exp)) {
+                throw new IllegalStateException("Missing expiration time (exp) claim");
+            }
+            if ((exp.getTime() + clockSkewInMillis) < currentTime) {
+                throw new IllegalStateException("Token is expired " + exp);
+            }
 
+            Date iat = claims.getIssueTime();
+            if (isNull(iat)) {
+                throw new IllegalStateException("Missing issue time (iat) claim");
+            }
+            if ((iat.getTime() - clockSkewInMillis) > currentTime) {
+                throw new IllegalStateException("Issue time must be after current time " + iat);
+            }
+        }
+    }
+
+    @Override
+    public void verify(JWTClaimsSet claims, SecurityContext c) throws BadJWTException {
+        StandardVerifications standardVerifications = new StandardVerifications(configuration, claims);
+
+        standardVerifications.requireSameIssuer();
+        standardVerifications.requireSubject();
+        standardVerifications.requireAudience(configuration.getClientId());
+        standardVerifications.assureAuthorizedParty(configuration.getClientId());
+        standardVerifications.requireValidTimestamp();
 
         verify(claims);
     }

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
@@ -141,6 +141,8 @@ public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
          * Claim.
          *
          * The current time must be after the time represented by the iat Claim.
+         *
+         * The current time must be after the time represented by nbf claim
          */
         public void requireValidTimestamp() {
             long clockSkewInMillis = TimeUnit.MINUTES.toMillis(1);
@@ -159,6 +161,11 @@ public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
             }
             if ((iat.getTime() - clockSkewInMillis) > currentTime) {
                 throw new IllegalStateException("Issue time must be after current time " + iat);
+            }
+
+            Date nbf = claims.getNotBeforeTime();
+            if (!isNull(nbf) && (nbf.getTime() - clockSkewInMillis) > currentTime) {
+                throw new IllegalStateException("Token is not valid before " + nbf);
             }
         }
     }

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
@@ -68,7 +68,7 @@ public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
         private final OpenIdConfiguration configuration;
         private final JWTClaimsSet claims;
 
-        protected StandardVerifications(OpenIdConfiguration configuration, JWTClaimsSet claims) {
+        public StandardVerifications(OpenIdConfiguration configuration, JWTClaimsSet claims) {
             this.configuration = configuration;
             this.claims = claims;
         }

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
@@ -38,30 +38,7 @@
 package fish.payara.security.openid.controller;
 
 import com.nimbusds.jose.Algorithm;
-import com.nimbusds.jose.EncryptionMethod;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEAlgorithm;
-import com.nimbusds.jose.JWEHeader;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.jwk.source.ImmutableSecret;
-import com.nimbusds.jose.jwk.source.JWKSource;
-import com.nimbusds.jose.jwk.source.RemoteJWKSet;
-import static com.nimbusds.jose.jwk.source.RemoteJWKSet.DEFAULT_HTTP_SIZE_LIMIT;
-import com.nimbusds.jose.proc.BadJOSEException;
-import com.nimbusds.jose.proc.JWEDecryptionKeySelector;
-import com.nimbusds.jose.proc.JWEKeySelector;
-import com.nimbusds.jose.proc.JWSKeySelector;
-import com.nimbusds.jose.proc.JWSVerificationKeySelector;
-import com.nimbusds.jose.util.DefaultResourceRetriever;
-import com.nimbusds.jose.util.ResourceRetriever;
-import com.nimbusds.jwt.EncryptedJWT;
-import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
-import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
-import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
 import fish.payara.security.openid.api.IdentityToken;
 import fish.payara.security.openid.api.RefreshToken;
@@ -71,11 +48,9 @@ import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdNonce;
 import fish.payara.security.openid.api.OpenIdConstant;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import java.text.ParseException;
 import static java.util.Collections.emptyMap;
 import java.util.Map;
-import static java.util.Objects.isNull;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
@@ -147,7 +122,7 @@ public class TokenController {
      * @param configuration the OpenId Connect client configuration configuration
      * @return JWT Claims
      */
-    public Map<String, Object> validateIdToken(IdentityTokenImpl idToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+    public JWTClaimsSet validateIdToken(IdentityTokenImpl idToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
         JWTClaimsSet claimsSet;
         HttpServletRequest request = httpContext.getRequest();
         HttpServletResponse response = httpContext.getResponse();
@@ -169,7 +144,7 @@ public class TokenController {
             nonceController.remove(configuration, request, response);
         }
 
-        return claimsSet.getClaims();
+        return claimsSet;
     }
 
     /**
@@ -181,10 +156,10 @@ public class TokenController {
      * @param configuration the OpenId Connect client configuration configuration
      * @return JWT Claims
      */
-    public Map<String, Object> validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+    public JWTClaimsSet validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
         JWTClaimsSetVerifier jwtVerifier = new RefreshedIdTokenClaimsSetVerifier(previousIdToken, configuration);
         JWTClaimsSet claimsSet = configuration.getJWTValidator().validateBearerToken(newIdToken.getTokenJWT(), jwtVerifier);
-        return claimsSet.getClaims();
+        return claimsSet;
     }
 
     /**

--- a/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
@@ -41,15 +41,20 @@ import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
 import fish.payara.security.openid.api.AccessToken;
 import java.text.ParseException;
 import static java.util.Collections.emptyMap;
 import java.util.Map;
+
+import fish.payara.security.openid.api.JwtClaims;
 import fish.payara.security.openid.api.Scope;
 import fish.payara.security.openid.api.OpenIdConstant;
 
 import java.util.Date;
+import java.util.Optional;
+
 import static java.util.Objects.nonNull;
 
 /**
@@ -61,6 +66,8 @@ public class AccessTokenImpl implements AccessToken {
     private final String token;
 
     private final AccessToken.Type type;
+
+    private final JwtClaims jwtClaims;
 
     private JWT tokenJWT;
 
@@ -77,32 +84,38 @@ public class AccessTokenImpl implements AccessToken {
     public AccessTokenImpl(OpenIdConfiguration configuration, String tokenType, String token, Long expiresIn, String scopeValue) {
         this.configuration = configuration;
         this.token = token;
+        JWTClaimsSet jwtClaimsSet = null;
         try {
             this.tokenJWT = JWTParser.parse(token);
-            this.claims = tokenJWT.getJWTClaimsSet().getClaims();
+            jwtClaimsSet = tokenJWT.getJWTClaimsSet();
+            this.claims = jwtClaimsSet.getClaims();
         } catch (ParseException ex) {
+            // Access token doesn't need to be JWT at all
         }
+        this.jwtClaims = NimbusJwtClaims.ifPresent(jwtClaimsSet);
+
         this.type = Type.valueOf(tokenType.toUpperCase());
         this.expiresIn = expiresIn;
         this.createdAt = System.currentTimeMillis();
         this.scope = Scope.parse(scopeValue);
     }
 
-    private AccessTokenImpl(OpenIdConfiguration configuration,JWT token, Map<String,Object> claims) throws ParseException {
+    private AccessTokenImpl(OpenIdConfiguration configuration, JWT token, JWTClaimsSet claims) {
         this.configuration = configuration;
         this.token = token.getParsedString();
         this.tokenJWT = token;
-        this.claims = claims;
+        this.claims = claims.getClaims();
+        this.jwtClaims = NimbusJwtClaims.ifPresent(claims);
         this.type = Type.BEARER;
         this.expiresIn = null;
         this.createdAt = System.currentTimeMillis();
-        this.scope = Scope.parse((String) claims.get(OpenIdConstant.SCOPE));
+        this.scope = jwtClaims.getStringClaim(OpenIdConstant.SCOPE).map(Scope::parse).orElse(null);
     }
 
     public static AccessTokenImpl forBearerToken(OpenIdConfiguration configuration, String rawToken, JWTClaimsSetVerifier validator) throws ParseException {
         JWT token = JWTParser.parse(rawToken);
         JWTClaimsSet claims = configuration.getJWTValidator().validateBearerToken(token, validator);
-        return new AccessTokenImpl(configuration, token, claims.getClaims());
+        return new AccessTokenImpl(configuration, token, claims);
     }
 
     public JWT getTokenJWT() {
@@ -160,12 +173,22 @@ public class AccessTokenImpl implements AccessToken {
         return scope;
     }
 
+    @Override
+    public boolean isJWT() {
+        return tokenJWT != null;
+    }
+
+    @Override
+    public JwtClaims getJwtClaims() {
+        return jwtClaims;
+    }
+
     public boolean isEncrypted() {
-        return tokenJWT != null && tokenJWT instanceof EncryptedJWT;
+        return isJWT() && tokenJWT instanceof EncryptedJWT;
     }
 
     public boolean isSigned() {
-        return tokenJWT != null && tokenJWT instanceof EncryptedJWT;
+        return isJWT() && tokenJWT instanceof SignedJWT;
     }
 
     @Override

--- a/openid/src/main/java/fish/payara/security/openid/domain/JWTValidator.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/JWTValidator.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.domain;
+
+import java.text.ParseException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWEDecryptionKeySelector;
+import com.nimbusds.jose.proc.JWEKeySelector;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.ResourceRetriever;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
+import fish.payara.security.openid.api.OpenIdConstant;
+
+import static com.nimbusds.jose.jwk.source.RemoteJWKSet.DEFAULT_HTTP_SIZE_LIMIT;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.isNull;
+
+public class JWTValidator {
+    private final OpenIdConfiguration configuration;
+    private ConcurrentHashMap<String, JWSKeySelector> jwsCache = new ConcurrentHashMap<>();
+    private JWEKeySelector jweKeySelector;
+
+    JWTValidator(OpenIdConfiguration openIdConfiguration) {
+        this.configuration = openIdConfiguration;
+    }
+
+    public JWTClaimsSet validateBearerToken(JWT token, JWTClaimsSetVerifier jwtVerifier) {
+        JWTClaimsSet claimsSet;
+        try {
+            if (token instanceof PlainJWT) {
+                PlainJWT plainToken = (PlainJWT) token;
+                claimsSet = plainToken.getJWTClaimsSet();
+                jwtVerifier.verify(claimsSet, null);
+            } else if (token instanceof SignedJWT) {
+                SignedJWT signedToken = (SignedJWT) token;
+                JWSHeader header = signedToken.getHeader();
+                String alg = header.getAlgorithm().getName();
+                if (isNull(alg)) {
+                    // set the default value
+                    alg = OpenIdConstant.DEFAULT_JWT_SIGNED_ALGORITHM;
+                }
+
+                ConfigurableJWTProcessor jwtProcessor = new DefaultJWTProcessor();
+                jwtProcessor.setJWSKeySelector(getJWSKeySelector(alg));
+                jwtProcessor.setJWTClaimsSetVerifier(jwtVerifier);
+                claimsSet = jwtProcessor.process(signedToken, null);
+            } else if (token instanceof EncryptedJWT) {
+                /**
+                 * If ID Token is encrypted, decrypt it using the keys and
+                 * algorithms
+                 */
+                EncryptedJWT encryptedToken = (EncryptedJWT) token;
+                JWEHeader header = encryptedToken.getHeader();
+                String alg = header.getAlgorithm().getName();
+
+                ConfigurableJWTProcessor jwtProcessor = new DefaultJWTProcessor();
+                jwtProcessor.setJWSKeySelector(getJWSKeySelector(alg));
+                jwtProcessor.setJWEKeySelector(getJWEKeySelector());
+                jwtProcessor.setJWTClaimsSetVerifier(jwtVerifier);
+                claimsSet = jwtProcessor.process(encryptedToken, null);
+            } else {
+                throw new IllegalStateException("Unexpected JWT type : " + token.getClass());
+            }
+        } catch (ParseException | BadJOSEException | JOSEException ex) {
+            throw new IllegalStateException(ex);
+        }
+        return claimsSet;
+    }
+
+    /**
+     * JWSKeySelector finds the JSON Web Key Set (JWKS) from jwks_uri endpoint
+     * and filter for potential signing keys in the JWKS with a matching kid
+     * property.
+     *
+     * @param alg the algorithm for the key
+     * @return the JSON Web Signing (JWS) key selector
+     */
+    private JWSKeySelector getJWSKeySelector(String alg) {
+        return jwsCache.computeIfAbsent(alg, this::createJWSKeySelector);
+    }
+
+    /**
+     * JWEKeySelector selects the key to decrypt JSON Web Encryption (JWE) and
+     * validate encrypted JWT.
+     *
+     * @return the JSON Web Encryption (JWE) key selector
+     */
+    private JWEKeySelector getJWEKeySelector() {
+        if (jweKeySelector != null) {
+            return jweKeySelector;
+        }
+
+        JWEAlgorithm jwsAlg = configuration.getEncryptionMetadata().getEncryptionAlgorithm();
+        EncryptionMethod jweEnc = configuration.getEncryptionMetadata().getEncryptionMethod();
+        JWKSource jwkSource = configuration.getEncryptionMetadata().getPrivateKeySource();
+
+        if (isNull(jwsAlg)) {
+            throw new IllegalStateException("Missing JWE encryption algorithm ");
+        }
+        if (!configuration.getProviderMetadata().getIdTokenEncryptionAlgorithmsSupported().contains(jwsAlg.getName())) {
+            throw new IllegalStateException("Unsupported ID tokens algorithm :" + jwsAlg.getName());
+        }
+        if (isNull(jweEnc)) {
+            throw new IllegalStateException("Missing JWE encryption method");
+        }
+        if (!configuration.getProviderMetadata().getIdTokenEncryptionMethodsSupported().contains(jweEnc.getName())) {
+            throw new IllegalStateException("Unsupported ID tokens encryption method :" + jweEnc.getName());
+        }
+
+        jweKeySelector = new JWEDecryptionKeySelector(jwsAlg, jweEnc, jwkSource);
+        return jweKeySelector;
+    }
+
+    private JWSKeySelector createJWSKeySelector(String alg) {
+        JWKSource jwkSource;
+        JWSAlgorithm jWSAlgorithm = new JWSAlgorithm(alg);
+        if (Algorithm.NONE.equals(jWSAlgorithm)) {
+            throw new IllegalStateException("Unsupported JWS algorithm : " + jWSAlgorithm);
+        } else if (JWSAlgorithm.Family.RSA.contains(jWSAlgorithm)
+                || JWSAlgorithm.Family.EC.contains(jWSAlgorithm)) {
+            ResourceRetriever jwkSetRetriever = new DefaultResourceRetriever(
+                    configuration.getJwksConnectTimeout(),
+                    configuration.getJwksReadTimeout(),
+                    DEFAULT_HTTP_SIZE_LIMIT
+            );
+            jwkSource = new RemoteJWKSet(configuration.getProviderMetadata().getJwksURL(), jwkSetRetriever);
+        } else if (JWSAlgorithm.Family.HMAC_SHA.contains(jWSAlgorithm)) {
+            byte[] clientSecret = new String(configuration.getClientSecret()).getBytes(UTF_8);
+            if (isNull(clientSecret)) {
+                throw new IllegalStateException("Missing client secret");
+            }
+            jwkSource = new ImmutableSecret(clientSecret);
+        } else {
+            throw new IllegalStateException("Unsupported JWS algorithm : " + jWSAlgorithm);
+        }
+        return new JWSVerificationKeySelector(jWSAlgorithm, jwkSource);
+    }
+
+}

--- a/openid/src/main/java/fish/payara/security/openid/domain/NimbusJwtClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/NimbusJwtClaims.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.domain;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import fish.payara.security.openid.api.JwtClaims;
+
+class NimbusJwtClaims implements JwtClaims {
+    private final JWTClaimsSet claimsSet;
+
+    NimbusJwtClaims(JWTClaimsSet claimsSet) {
+        this.claimsSet = claimsSet;
+    }
+
+    @Override
+    public Optional<String> getStringClaim(String name) {
+        try {
+            return Optional.ofNullable(claimsSet.getStringClaim(name));
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as string", e);
+        }
+    }
+
+    @Override
+    public Optional<Instant> getNumericDateClaim(String name) {
+        try {
+            return Optional.ofNullable(claimsSet.getDateClaim(name)).map(Date::toInstant);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as numeric date", e);
+        }
+    }
+
+    @Override
+    public List<String> getArrayStringClaim(String name) {
+        Object audValue = claimsSet.getClaim(name);
+        if (audValue == null) {
+            return Collections.emptyList();
+        }
+        if (audValue instanceof String) {
+            return Collections.singletonList((String)audValue);
+        }
+        List<String> aud;
+        try {
+            return claimsSet.getStringListClaim(name);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as a string array", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return claimsSet.toString();
+    }
+
+    static JwtClaims ifPresent(JWTClaimsSet claimsSet) {
+        return claimsSet == null ? JwtClaims.NONE : new NimbusJwtClaims(claimsSet);
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/domain/NimbusJwtClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/NimbusJwtClaims.java
@@ -44,6 +44,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import fish.payara.security.openid.api.JwtClaims;
@@ -88,6 +91,39 @@ class NimbusJwtClaims implements JwtClaims {
         } catch (ParseException e) {
             throw new IllegalArgumentException("Cannot parse "+name+" as a string array", e);
         }
+    }
+
+    @Override
+    public OptionalInt getIntClaim(String name) {
+        Integer value = null;
+        try {
+            value = claimsSet.getIntegerClaim(name);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as number");
+        }
+        return value == null ? OptionalInt.empty() : OptionalInt.of(value);
+    }
+
+    @Override
+    public OptionalLong getLongClaim(String name) {
+        Long value = null;
+        try {
+            value = claimsSet.getLongClaim(name);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as number");
+        }
+        return value == null ? OptionalLong.empty() : OptionalLong.of(value);
+    }
+
+    @Override
+    public OptionalDouble getDoubleClaim(String name) {
+        Double value = null;
+        try {
+            value = claimsSet.getDoubleClaim(name);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Cannot parse "+name+" as number");
+        }
+        return value == null ? OptionalDouble.empty() : OptionalDouble.of(value);
     }
 
     @Override

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -67,6 +67,7 @@ public class OpenIdConfiguration {
     private LogoutConfiguration logoutConfiguration;
     private boolean tokenAutoRefresh;
     private int tokenMinValidity;
+    private JWTValidator validator;
 
     static final String BASE_URL_EXPRESSION = "${baseURL}";
 
@@ -273,4 +274,10 @@ public class OpenIdConfiguration {
                 + '}';
     }
 
+    public JWTValidator getJWTValidator() {
+        if (this.validator == null) {
+            this.validator = new JWTValidator(this);
+        }
+        return this.validator;
+    }
 }

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -191,6 +191,10 @@ public class OpenIdContextImpl implements OpenIdContext {
             session.invalidate();
         }
 
+        if (logout == null) {
+            LOGGER.log(WARNING, "Logout invoked on session without OpenID session");
+            redirect(response, request.getContextPath());
+        }
         /**
          * See section 5. RP-Initiated Logout
          * https://openid.net/specs/openid-connect-session-1_0.html#RPLogout
@@ -203,20 +207,20 @@ public class OpenIdContextImpl implements OpenIdContext {
                 // User Agent redirected to POST_LOGOUT_REDIRECT_URI after a logout operation performed in OP.
                 logoutURI.queryParam(OpenIdConstant.POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
             }
-            try {
-                response.sendRedirect(logoutURI.toString());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+            redirect(response, logoutURI.toString());
         } else if (!OpenIdUtil.isEmpty(logout.getRedirectURI())) {
-            try {
-                response.sendRedirect(logout.buildRedirectURI(request));
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+            redirect(response, logout.buildRedirectURI(request));
         } else {
             // Redirect user to OpenID connect provider for re-authentication
             authenticationController.authenticateUser(configuration, request, response);
+        }
+    }
+
+    private static void redirect(HttpServletResponse response, String uri) {
+        try {
+            response.sendRedirect(uri);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -45,6 +45,7 @@ import fish.payara.security.openid.api.RefreshToken;
 import fish.payara.security.openid.controller.AuthenticationController;
 import fish.payara.security.openid.OpenIdUtil;
 import fish.payara.security.openid.api.OpenIdConstant;
+import fish.payara.security.openid.controller.UserInfoController;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -69,6 +70,8 @@ import javax.ws.rs.core.UriBuilder;
  */
 @SessionScoped
 public class OpenIdContextImpl implements OpenIdContext {
+    @Inject
+    UserInfoController userInfoController;
 
     private String callerName;
     private Set<String> callerGroups;
@@ -156,7 +159,11 @@ public class OpenIdContextImpl implements OpenIdContext {
     @Override
     public JsonObject getClaimsJson() {
         if (claims == null) {
-            return Json.createObjectBuilder().build();
+            if (configuration != null && accessToken != null) {
+                claims = userInfoController.getUserInfo(configuration, accessToken);
+            } else {
+                claims = Json.createObjectBuilder().build();
+            }
         }
         return claims;
     }
@@ -164,10 +171,6 @@ public class OpenIdContextImpl implements OpenIdContext {
     @Override
     public OpenIdClaims getClaims() {
         return new OpenIdClaims(getClaimsJson());
-    }
-
-    public void setClaims(JsonObject claims) {
-        this.claims = claims;
     }
 
     @Override

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -170,7 +170,7 @@ public class OpenIdContextImpl implements OpenIdContext {
 
     @Override
     public OpenIdClaims getClaims() {
-        return new OpenIdClaims(getClaimsJson());
+        return new JsonClaims(getClaimsJson());
     }
 
     @Override

--- a/openid/src/test/java/fish/payara/security/openid/domain/NimbusJwtClaimsTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/NimbusJwtClaimsTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.domain;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import fish.payara.security.openid.api.JwtClaims;
+import fish.payara.security.openid.api.OpenIdConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NimbusJwtClaimsTest {
+    private JwtClaims cut;
+
+    @Nested
+    @DisplayName("getStringClaim")
+    class StringClaimTest {
+        @Test
+        public void notExistingReturnsEmpty() {
+            assumeClaims(b -> b);
+            assertEmpty(cut.getStringClaim("any"));
+        }
+
+        @Test
+        public void notStringThrows() {
+            assumeClaims(b -> b.claim("any", 1));
+            assertThrows(IllegalArgumentException.class, () -> cut.getStringClaim("any"));
+        }
+
+        @Test
+        public void existingStringPresent() {
+            assumeClaims(b -> b.issuer("me"));
+            assertPresentAndEqual(cut.getIssuer(), "me");
+        }
+    }
+
+    @Nested
+    @DisplayName("getNumberDateClaim")
+    class NumericDateClaimTest {
+        @Test
+        public void notExistingReturnsEmpty() {
+            assumeClaims(b -> b);
+            assertEmpty(cut.getNumericDateClaim("any"));
+        }
+
+        @Test
+        public void notNumberThrows() {
+            assumeClaims(b -> b.claim("any", "a"));
+            assertThrows(IllegalArgumentException.class, () -> cut.getNumericDateClaim("any"));
+        }
+
+        @Test
+        public void existingNumberPresent() {
+            OffsetDateTime referenceDate = OffsetDateTime.of(LocalDate.of(2021, 2, 3), LocalTime.of(14, 16), ZoneOffset.UTC);
+            assumeClaims(b -> b.claim("date", referenceDate.toEpochSecond()));
+            assertPresentAndEqual(cut.getNumericDateClaim("date"), referenceDate.toInstant());
+        }
+    }
+
+    @Nested
+    @DisplayName("isExpired")
+    class ExpirationTest {
+        Duration skew = Duration.ofMinutes(1);
+
+
+        @Test
+        public void nonExistingNotRequired() {
+            assumeClaims(b -> b);
+            assertFalse(cut.isExpired(Clock.systemUTC(), false, skew), "When not required and expiration not present, should not be expired");
+        }
+
+        @Test
+        public void nonExistingRequired() {
+            assumeClaims(b -> b);
+            assertTrue(cut.isExpired(Clock.systemUTC(), true, skew), "When required and expiration not present, should be expired");
+        }
+
+        @Test
+        public void beforeExpiration() {
+            Instant expirationTime = Instant.parse("2021-03-02T14:50:00Z");
+            assumeClaims(b -> b.claim(OpenIdConstant.EXPIRATION_IDENTIFIER, expirationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:23:00Z");
+            assertFalse(cut.isExpired(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When before expiration time, should not be expired");
+        }
+
+        @Test
+        public void withinSkew() {
+            Instant expirationTime = Instant.parse("2021-03-02T14:50:00Z");
+            assumeClaims(b -> b.claim(OpenIdConstant.EXPIRATION_IDENTIFIER, expirationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:50:59.999Z");
+            assertFalse(cut.isExpired(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When within clock skew, should not be expired");
+        }
+
+        @Test
+        public void expired() {
+            Instant expirationTime = Instant.parse("2021-03-02T14:50:00Z");
+            assumeClaims(b -> b.claim(OpenIdConstant.EXPIRATION_IDENTIFIER, expirationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:51:01Z");
+            assertTrue(cut.isExpired(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When outside clock skew, should be expired");
+        }
+    }
+
+    @Nested
+    @DisplayName("isBeforeValidity")
+    class BeforeValidityTest {
+        Duration skew = Duration.ofMinutes(1);
+
+
+        @Test
+        public void nonExistingNotRequired() {
+            assumeClaims(b -> b);
+            assertFalse(cut.isBeforeValidity(Clock.systemUTC(), false, skew), "When not required and nbf not present, should not be before validity");
+        }
+
+        @Test
+        public void nonExistingRequired() {
+            assumeClaims(b -> b);
+            assertTrue(cut.isBeforeValidity(Clock.systemUTC(), true, skew), "When required and nbf not present, should be before validity");
+        }
+
+        @Test
+        public void afterValidity() {
+            Instant initiationTime = Instant.parse("2021-03-02T14:23:00Z");
+            assumeClaims(b -> b.claim("nbf", initiationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:50:00Z");
+            assertFalse(cut.isBeforeValidity(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When after nbf time, should not be before validity");
+        }
+
+        @Test
+        public void withinSkew() {
+            Instant initiationTime = Instant.parse("2021-03-02T14:23:00Z");
+            assumeClaims(b -> b.claim("nbf", initiationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:22:00.001Z");
+            assertFalse(cut.isBeforeValidity(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When within clock skew, should not be before validity");
+        }
+
+        @Test
+        public void beforeValidity() {
+            Instant initiationTime = Instant.parse("2021-03-02T14:50:00Z");
+            assumeClaims(b -> b.claim(OpenIdConstant.EXPIRATION_IDENTIFIER, initiationTime.getEpochSecond()));
+
+            Instant testTime = Instant.parse("2021-03-02T14:23:00Z");
+            assertTrue(cut.isBeforeValidity(Clock.fixed(testTime, ZoneOffset.UTC), true, skew), "When before validity, then it really should be");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAudience")
+    class AudienceTest {
+        @Test
+        public void notExistingReturnsEmpty() {
+            assumeClaims(b -> b);
+            assertTrue(cut.getAudience().isEmpty());
+        }
+
+        @Test
+        public void notStringThrows() {
+            assumeClaims(b -> b.claim(OpenIdConstant.AUDIENCE, 1));
+            assertThrows(IllegalArgumentException.class, () -> cut.getAudience());
+        }
+
+        @Test
+        public void singleValueIsSingletonList() {
+            assumeClaims(b -> b.audience("a"));
+            assertEquals(Collections.singletonList("a"), cut.getAudience());
+        }
+
+        @Test
+        public void multiValueIsList() {
+            assumeClaims(b -> b.audience(Arrays.asList("a", "b")));
+            assertEquals(Arrays.asList("a", "b"), cut.getAudience());
+        }
+    }
+
+    @Test
+    public void returnsEmptyOnNullClaims() {
+        this.cut = NimbusJwtClaims.ifPresent(null);
+        assertEmpty(cut.getStringClaim("any"));
+        assertEmpty(cut.getIssuer());
+        assertEmpty(cut.getSubject());
+        assertEmpty(cut.getAudience());
+        assertEmpty(cut.getExpirationTime());
+        assertEmpty(cut.getJwtId());
+        assertEmpty(cut.getIssuedAt());
+        assertEmpty(cut.getNotBeforeTime());
+        assertEmpty(cut.getNumericDateClaim("any"));
+        assertFalse(cut.getIntClaim("any").isPresent(), "Value should not be present");
+        assertFalse(cut.getLongClaim("any").isPresent(), "Value should not be present");
+        assertFalse(cut.getDoubleClaim("any").isPresent(), "Value should not be present");
+    }
+
+    static <T> void  assertPresentAndEqual(Optional<T> optional, T value) {
+        assertPresent(optional);
+        assertEquals(value, optional.get());
+    }
+
+
+    static void assertEmpty(List<String> list) {
+        assertTrue(list.isEmpty(), "Value should not be present");
+    }
+
+    static JWTClaimsSet.Builder builder() {
+        return new JWTClaimsSet.Builder();
+    }
+
+    JwtClaims assumeClaims(Function<JWTClaimsSet.Builder, JWTClaimsSet.Builder> buildup) {
+        this.cut = NimbusJwtClaims.ifPresent(buildup.apply(builder()).build());
+        return cut;
+    }
+
+    static void assertPresent(Optional<?> opt) {
+        assertTrue(opt.isPresent(), "Value should be present");
+    }
+
+    static void assertEmpty(Optional<?> opt) {
+        assertFalse(opt.isPresent(), "Value should not be present");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,8 @@
         <javax.security.enterprise.version>1.1-b01.payara-p4</javax.security.enterprise.version>
         <nimbus-jose-jwt.version>9.2</nimbus-jose-jwt.version>
         <accessors-smart.version>1.2.payara-p2</accessors-smart.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
@@ -128,6 +130,37 @@
                 <groupId>net.minidev</groupId>
                 <artifactId>accessors-smart</artifactId>
                 <version>${accessors-smart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.19.0</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -193,6 +226,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Bearer authentication expects JWT access token, that has been signed by the issuer. Token is validated for basic attributes (sub, iss, iat,nbf,  exp).

Application is expected to ship group providing IdentityStore, that read the access token from AccessTokenCallerPrincipal and decide caller's roles based on claims of the token (mostly audience and scope). There are too many application-specific options to put in an annotation.

Some of the things were refactored for better reuse and caching of remote resources (i. e. JWKS)
Other things were refactored to have more typesafe interface -- JwtClaims and OpenIdClaims are both read-only interfaces now, that return Optional values, as more often null than one would with (i. e. user that wouldn't allow access to personal information).


Tested in Payara Cloud, will yet consider following steps:

* [x] IdToken claims should also implement Claims interface rather than old Map interface.