### PR TITLE
CLOUD-463: Allow programmiatic validation of JWT Access token

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenCredential.java
@@ -43,11 +43,9 @@ import javax.security.enterprise.credential.Credential;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 
 public class AccessTokenCredential implements Credential {
-    private final OpenIdConfiguration configuration;
     private final String accessToken;
 
-    AccessTokenCredential(OpenIdConfiguration configuration, String accessToken) {
-        this.configuration = configuration;
+    AccessTokenCredential(String accessToken) {
         this.accessToken = accessToken;
     }
 
@@ -55,7 +53,4 @@ public class AccessTokenCredential implements Credential {
         return accessToken;
     }
 
-    OpenIdConfiguration getConfiguration() {
-        return configuration;
-    }
 }

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -54,6 +54,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.BadJWTException;
 import fish.payara.security.openid.api.AccessTokenCallerPrincipal;
 import fish.payara.security.openid.api.AccessTokenCredential;
+import fish.payara.security.openid.controller.JWTValidator;
 import fish.payara.security.openid.controller.TokenClaimsSetVerifier;
 import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
@@ -74,12 +75,15 @@ public class AccessTokenIdentityStore implements IdentityStore {
     @Inject
     OpenIdConfiguration configuration;
 
+    @Inject
+    JWTValidator validator;
+
     @SuppressWarnings("unused")
     public CredentialValidationResult validate(AccessTokenCredential credential) {
         try {
             AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(configuration,
                     credential.getAccessToken(),
-                    new BearerVerifier(configuration));
+                    new BearerVerifier(configuration), validator);
             context.setAccessToken(accessToken);
             // for setClaims we'd need to invoke userinfo. That should be lazy unless required
             context.setCallerName(

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -53,7 +53,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.BadJWTException;
 import fish.payara.security.openid.api.AccessTokenCallerPrincipal;
-import fish.payara.security.openid.api.OpenIdConstant;
+import fish.payara.security.openid.api.AccessTokenCredential;
 import fish.payara.security.openid.controller.TokenClaimsSetVerifier;
 import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
@@ -91,7 +91,7 @@ public class AccessTokenIdentityStore implements IdentityStore {
                                     .orElse(null)));
 
             return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken, context::getClaims));
-        } catch (ParseException e) {
+        } catch (ParseException | RuntimeException e) {
             LOGGER.log(Level.WARNING, "Cannot parse access token", e);
         }
         return CredentialValidationResult.INVALID_RESULT;

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -71,18 +71,21 @@ public class AccessTokenIdentityStore implements IdentityStore {
     @Inject
     OpenIdContextImpl context;
 
+    @Inject
+    OpenIdConfiguration configuration;
+
     @SuppressWarnings("unused")
     public CredentialValidationResult validate(AccessTokenCredential credential) {
         try {
-            AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(credential.getConfiguration(),
+            AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(configuration,
                     credential.getAccessToken(),
-                    new BearerVerifier(credential.getConfiguration()));
+                    new BearerVerifier(configuration));
             context.setAccessToken(accessToken);
             // for setClaims we'd need to invoke userinfo. That should be lazy unless required
             context.setCallerName(
                     // use configured caller name claim if present in access token
                     accessToken.getJwtClaims().getStringClaim(
-                            credential.getConfiguration().getClaimsConfiguration().getCallerNameClaim())
+                            configuration.getClaimsConfiguration().getCallerNameClaim())
                             // or subject, which is more likely present, but is still optional per JWT spec
                             .orElse(accessToken.getJwtClaims().getSubject()
                                     .orElse(null)));

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -37,7 +37,6 @@
  */
 package fish.payara.security.openid;
 
-import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
 import static fish.payara.security.openid.OpenIdUtil.isEmpty;
 import static fish.payara.security.openid.api.OpenIdConstant.ERROR_DESCRIPTION_PARAM;
 import static fish.payara.security.openid.api.OpenIdConstant.ERROR_PARAM;
@@ -45,6 +44,8 @@ import static fish.payara.security.openid.api.OpenIdConstant.EXPIRES_IN;
 import static fish.payara.security.openid.api.OpenIdConstant.REFRESH_TOKEN;
 import static fish.payara.security.openid.api.OpenIdConstant.STATE;
 import static fish.payara.security.openid.api.OpenIdConstant.TOKEN_TYPE;
+
+import fish.payara.security.openid.api.AccessTokenCredential;
 import fish.payara.security.openid.api.OpenIdState;
 import fish.payara.security.openid.api.RefreshToken;
 import fish.payara.security.openid.controller.AuthenticationController;

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
@@ -61,17 +61,15 @@ public class OpenIdCredential implements Credential {
 
     private final HttpMessageContext httpContext;
 
-    private final OpenIdConfiguration configuration;
 
     private final IdentityTokenImpl identityToken;
 
     private AccessToken accessToken;
 
-    public OpenIdCredential(JsonObject tokensObject, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+    public OpenIdCredential(JsonObject tokensObject, HttpMessageContext httpContext, long tokenMinValidity) {
         this.httpContext = httpContext;
-        this.configuration = configuration;
 
-        this.identityToken = new IdentityTokenImpl(configuration, tokensObject.getString(IDENTITY_TOKEN));
+        this.identityToken = new IdentityTokenImpl(tokensObject.getString(IDENTITY_TOKEN), tokenMinValidity);
         String accessTokenString = tokensObject.getString(ACCESS_TOKEN, null);
         Long expiresIn = null;
         if(nonNull(tokensObject.getJsonNumber(EXPIRES_IN))){
@@ -80,7 +78,7 @@ public class OpenIdCredential implements Credential {
         String tokenType = tokensObject.getString(TOKEN_TYPE, null);
         String scopeString = tokensObject.getString(SCOPE, null);
         if (nonNull(accessTokenString)) {
-            accessToken = new AccessTokenImpl(configuration, tokenType, accessTokenString, expiresIn, scopeString);
+            accessToken = new AccessTokenImpl(tokenType, accessTokenString, expiresIn, scopeString, tokenMinValidity);
         }
     }
 
@@ -98,10 +96,6 @@ public class OpenIdCredential implements Credential {
 
     public HttpMessageContext getHttpContext() {
         return httpContext;
-    }
-
-    public OpenIdConfiguration getConfiguration() {
-        return configuration;
     }
 
 }

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -50,18 +50,14 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import java.util.Set;
-import static java.util.stream.Collectors.toSet;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
 import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -83,35 +79,34 @@ public class OpenIdIdentityStore implements IdentityStore {
     private TokenController tokenController;
 
     @Inject
-    private UserInfoController userInfoController;
+    private OpenIdConfiguration configuration;
 
     @SuppressWarnings("unused") // IdentityStore calls overloads
     public CredentialValidationResult validate(OpenIdCredential credential) {
         HttpMessageContext httpContext = credential.getHttpContext();
-        OpenIdConfiguration configuration = credential.getConfiguration();
         IdentityTokenImpl idToken = credential.getIdentityTokenImpl();
         
         Algorithm idTokenAlgorithm = idToken.getTokenJWT().getHeader().getAlgorithm();
         
         JWTClaimsSet idTokenClaims;
         if (isNull(context.getIdentityToken())) {
-            idTokenClaims = tokenController.validateIdToken(idToken, httpContext, configuration);
+            idTokenClaims = tokenController.validateIdToken(idToken, httpContext);
         } else {
             // If an ID Token is returned as a result of a token refresh request
-            idTokenClaims = tokenController.validateRefreshedIdToken(context.getIdentityToken(), idToken, httpContext, configuration);
+            idTokenClaims = tokenController.validateRefreshedIdToken(context.getIdentityToken(), idToken, httpContext);
         }
         context.setIdentityToken(idToken.withClaims(idTokenClaims));
 
         AccessTokenImpl accessToken = (AccessTokenImpl) credential.getAccessToken();
         if (nonNull(accessToken)) {
             tokenController.validateAccessToken(
-                    accessToken, idTokenAlgorithm, context.getIdentityToken().getClaims(), configuration
+                    accessToken, idTokenAlgorithm, context.getIdentityToken().getClaims()
             );
             context.setAccessToken(accessToken);
         }
 
-        context.setCallerName(getCallerName(configuration));
-        context.setCallerGroups(getCallerGroups(configuration));
+        context.setCallerName(getCallerName());
+        context.setCallerGroups(getCallerGroups());
 
         return new CredentialValidationResult(
                 context.getCallerName(),
@@ -119,7 +114,7 @@ public class OpenIdIdentityStore implements IdentityStore {
         );
     }
 
-    private String getCallerName(OpenIdConfiguration configuration) {
+    private String getCallerName() {
         String callerNameClaim = configuration.getClaimsConfiguration().getCallerNameClaim();
         if (OpenIdConstant.SUBJECT_IDENTIFIER.equals(callerNameClaim)) {
             return context.getSubject();
@@ -137,7 +132,7 @@ public class OpenIdIdentityStore implements IdentityStore {
         return callerName;
     }
 
-    private Set<String> getCallerGroups(OpenIdConfiguration configuration) {
+    private Set<String> getCallerGroups() {
         String callerGroupsClaim = configuration.getClaimsConfiguration().getCallerGroupsClaim();
         List<String> groupsAccessClaim
                 = context.getAccessToken().getJwtClaims().getArrayStringClaim(callerGroupsClaim);

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -41,7 +41,6 @@ import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jwt.JWTClaimsSet;
 import fish.payara.security.openid.api.OpenIdConstant;
 import fish.payara.security.openid.controller.TokenController;
-import fish.payara.security.openid.controller.UserInfoController;
 import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.IdentityTokenImpl;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
@@ -93,7 +92,7 @@ public class OpenIdIdentityStore implements IdentityStore {
             idTokenClaims = tokenController.validateIdToken(idToken, httpContext);
         } else {
             // If an ID Token is returned as a result of a token refresh request
-            idTokenClaims = tokenController.validateRefreshedIdToken(context.getIdentityToken(), idToken, httpContext);
+            idTokenClaims = tokenController.validateRefreshedIdToken(context.getIdentityToken(), idToken);
         }
         context.setIdentityToken(idToken.withClaims(idTokenClaims));
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -69,7 +69,7 @@ public final class OpenIdUtil {
     }
 
     public static boolean isELExpression(String expression) {
-        return !expression.isEmpty() && isDeferredExpression(expression);
+        return expression != null && !expression.isEmpty() && isDeferredExpression(expression);
     }
 
     public static boolean isDeferredExpression(String expression) {

--- a/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/api/AccessTokenCredential.java
@@ -36,7 +36,7 @@
  *  holder.
  */
 
-package fish.payara.security.openid;
+package fish.payara.security.openid.api;
 
 import javax.security.enterprise.credential.Credential;
 
@@ -45,7 +45,7 @@ import fish.payara.security.openid.domain.OpenIdConfiguration;
 public class AccessTokenCredential implements Credential {
     private final String accessToken;
 
-    AccessTokenCredential(String accessToken) {
+    public AccessTokenCredential(String accessToken) {
         this.accessToken = accessToken;
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/AuthenticationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/AuthenticationController.java
@@ -68,6 +68,9 @@ public class AuthenticationController {
     @Inject
     private NonceController nonceController;
 
+    @Inject
+    private OpenIdConfiguration configuration;
+
     private static final Logger LOGGER = Logger.getLogger(AuthenticationController.class.getName());
 
     /**
@@ -80,13 +83,11 @@ public class AuthenticationController {
      * Authorization Code.
      *
      *
-     * @param configuration the OpenId Connect client configuration configuration
      * @param request
      * @param response
      * @return
      */
     public AuthenticationStatus authenticateUser(
-            OpenIdConfiguration configuration,
             HttpServletRequest request,
             HttpServletResponse response) {
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/CacheKey.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/CacheKey.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.security.openid.controller;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+class CacheKey {
+    private final Object[] attributes;
+    private int hashCode;
+
+    CacheKey(Object... attributes) {
+        this.attributes = attributes;
+        this.hashCode = Objects.hash(attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CacheKey that = (CacheKey) o;
+        return hashCode == that.hashCode && Arrays.equals(attributes, that.attributes);
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -51,9 +51,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
 import static java.util.stream.Collectors.joining;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.json.JsonObject;
 
@@ -73,9 +79,23 @@ import org.eclipse.microprofile.config.ConfigProvider;
 public class ConfigurationController {
 
     @Inject
-    private ProviderMetadataContoller configurationContoller;
+    private ProviderMetadataContoller providerMetadataContoller;
 
     private static final String SPACE_SEPARATOR = " ";
+
+    private volatile LastBuiltConfig lastBuiltConfig = new LastBuiltConfig(null, null);
+
+    @Produces
+    @RequestScoped
+    public OpenIdConfiguration produceConfiguration(OpenIdAuthenticationDefinition definition) {
+        OpenIdConfiguration cached = lastBuiltConfig.cachedConfiguration(definition);
+        if (cached != null) {
+            return cached;
+        }
+        OpenIdConfiguration config = buildConfig(definition);
+        lastBuiltConfig = new LastBuiltConfig(definition, config);
+        return config;
+    }
 
     /**
      * Creates the {@link OpenIdConfiguration} using the properties as defined
@@ -100,7 +120,7 @@ public class ConfigurationController {
 
         providerURI = OpenIdUtil.getConfiguredValue(String.class, definition.providerURI(), provider, OpenIdAuthenticationDefinition.OPENID_MP_PROVIDER_URI);
         fish.payara.security.annotations.OpenIdProviderMetadata providerMetadata = definition.providerMetadata();
-        providerDocument = configurationContoller.getDocument(providerURI);
+        providerDocument = providerMetadataContoller.getDocument(providerURI);
 
         if (OpenIdUtil.isEmpty(providerMetadata.authorizationEndpoint()) && providerDocument.containsKey(OpenIdConstant.AUTHORIZATION_ENDPOINT)) {
             authorizationEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.AUTHORIZATION_ENDPOINT), provider, OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT);
@@ -318,6 +338,107 @@ public class ConfigurationController {
         }
 
         return errorMessages;
+    }
+
+    static class LastBuiltConfig {
+        private final OpenIdAuthenticationDefinition definition;
+        private final OpenIdConfiguration configuration;
+
+        public LastBuiltConfig(OpenIdAuthenticationDefinition definition, OpenIdConfiguration configuration) {
+            this.definition = definition;
+            this.configuration = configuration;
+        }
+
+        OpenIdConfiguration cachedConfiguration(OpenIdAuthenticationDefinition definition) {
+            if (this.definition != null && this.definition.equals(definition)) {
+                return configuration;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Behavior-relevant attributes of a definition as a key for configuration cache.
+     * This can serve as a key to a cache of OpenIdConfiguration objects if configuration varies among requests, which
+     * is a feature coming soon.
+     */
+    static class DefinitionKey {
+        private final String[] attributes;
+        private int hashCode;
+
+        DefinitionKey(String... attributes) {
+            this.attributes = attributes;
+            this.hashCode = Objects.hash(attributes);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DefinitionKey that = (DefinitionKey) o;
+            return hashCode == that.hashCode && Arrays.equals(attributes, that.attributes);
+        }
+
+        static DefinitionKey fromDefinition(OpenIdAuthenticationDefinition definition) {
+            String[][] values = {
+                    {
+                            definition.providerURI(),
+                            definition.clientId(),
+                            definition.clientSecret(),
+                            definition.redirectURI(),
+                            definition.responseType(),
+                            definition.responseMode(),
+                            Arrays.toString(definition.prompt()),
+                            String.valueOf(definition.useNonce()),
+                            String.valueOf(definition.useSession()),
+                            String.valueOf(definition.tokenAutoRefresh()),
+                            String.valueOf(definition.tokenMinValidity())
+                    },
+                    definition.scope(),
+                    definition.extraParameters(),
+                    providerMetadataAttrs(definition.providerMetadata()),
+                    claimsAttrs(definition.claimsDefinition()),
+                    logoutAttrs(definition.logout())
+            };
+
+            // and now concatentate all of these together to form a key
+            return new DefinitionKey(Stream.of(values).flatMap(Stream::of).toArray(String[]::new));
+        }
+
+        private static String[] logoutAttrs(LogoutDefinition logout) {
+            return logout != null ? new String[] {
+                    String.valueOf(logout.notifyProvider()),
+                    logout.redirectURI(),
+                    String.valueOf(logout.accessTokenExpiry()),
+                    String.valueOf(logout.identityTokenExpiry())
+            } : new String[4];
+        }
+
+        private static String[] claimsAttrs(ClaimsDefinition claimsDefinition) {
+            return claimsDefinition != null ? new String[] {
+                    claimsDefinition.callerGroupsClaim(),
+                    claimsDefinition.callerNameClaim()
+            } : new String[2];
+        }
+
+        private static String[] providerMetadataAttrs(OpenIdProviderMetadata providerMetadata) {
+            return providerMetadata != null ? new String[]{
+                    providerMetadata.authorizationEndpoint(),
+                    providerMetadata.tokenEndpoint(),
+                    providerMetadata.userinfoEndpoint(),
+                    providerMetadata.endSessionEndpoint(),
+                    providerMetadata.jwksURI(),
+            } : new String[5];
+        }
     }
 
 }

--- a/openid/src/main/java/fish/payara/security/openid/controller/StateController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/StateController.java
@@ -44,6 +44,8 @@ import fish.payara.security.openid.http.HttpStorageController;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.Optional;
+
+import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -57,6 +59,9 @@ public class StateController {
 
     private static final String STATE_KEY = "oidc.state";
 
+    @Inject
+    OpenIdConfiguration configuration;
+
     public void store(
             OpenIdState state,
             OpenIdConfiguration configuration,
@@ -68,7 +73,6 @@ public class StateController {
     }
 
     public Optional<OpenIdState> get(
-            OpenIdConfiguration configuration,
             HttpServletRequest request,
             HttpServletResponse response) {
 
@@ -79,7 +83,6 @@ public class StateController {
     }
 
     public void remove(
-            OpenIdConfiguration configuration,
             HttpServletRequest request,
             HttpServletResponse response) {
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
@@ -75,16 +75,18 @@ public class TokenController {
     @Inject
     private NonceController nonceController;
 
+    @Inject
+    OpenIdConfiguration configuration;
+
     /**
      * (4) A Client makes a token request to the token endpoint and the OpenId
      * Provider responds with an ID Token and an Access Token.
      *
-     * @param configuration the OpenId Connect client configuration configuration
      * @param request
      * @return a JSON object representation of OpenID Connect token response
      * from the Token endpoint.
      */
-    public Response getTokens(OpenIdConfiguration configuration, HttpServletRequest request) {
+    public Response getTokens(HttpServletRequest request) {
         /**
          * one-time authorization code that RP exchange for an Access / Id token
          */
@@ -119,10 +121,9 @@ public class TokenController {
      *
      * @param idToken
      * @param httpContext
-     * @param configuration the OpenId Connect client configuration configuration
      * @return JWT Claims
      */
-    public JWTClaimsSet validateIdToken(IdentityTokenImpl idToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+    public JWTClaimsSet validateIdToken(IdentityTokenImpl idToken, HttpMessageContext httpContext) {
         JWTClaimsSet claimsSet;
         HttpServletRequest request = httpContext.getRequest();
         HttpServletResponse response = httpContext.getResponse();
@@ -153,10 +154,9 @@ public class TokenController {
      * @param previousIdToken
      * @param newIdToken
      * @param httpContext
-     * @param configuration the OpenId Connect client configuration configuration
      * @return JWT Claims
      */
-    public JWTClaimsSet validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext, OpenIdConfiguration configuration) {
+    public JWTClaimsSet validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext) {
         JWTClaimsSetVerifier jwtVerifier = new RefreshedIdTokenClaimsSetVerifier(previousIdToken, configuration);
         JWTClaimsSet claimsSet = configuration.getJWTValidator().validateBearerToken(newIdToken.getTokenJWT(), jwtVerifier);
         return claimsSet;
@@ -168,10 +168,9 @@ public class TokenController {
      * @param accessToken
      * @param idTokenAlgorithm
      * @param idTokenClaims
-     * @param configuration the OpenId Connect client configuration configuration
      * @return JWT Claims
      */
-    public Map<String, Object> validateAccessToken(AccessTokenImpl accessToken, Algorithm idTokenAlgorithm, Map<String, Object> idTokenClaims, OpenIdConfiguration configuration) {
+    public Map<String, Object> validateAccessToken(AccessTokenImpl accessToken, Algorithm idTokenAlgorithm, Map<String, Object> idTokenClaims) {
         Map<String, Object> claims = emptyMap();
 
         AccessTokenClaimsSetVerifier jwtVerifier = new AccessTokenClaimsSetVerifier(
@@ -196,12 +195,11 @@ public class TokenController {
      * Makes a refresh request to the token endpoint and the OpenId Provider
      * responds with a new (updated) Access Token and Refreshs Token.
      *
-     * @param configuration the OpenId Connect client configuration configuration
      * @param refreshToken Refresh Token received from previous token request.
      * @return a JSON object representation of OpenID Connect token response
      * from the Token endpoint.
      */
-    public Response refreshTokens(OpenIdConfiguration configuration, RefreshToken refreshToken) {
+    public Response refreshTokens(RefreshToken refreshToken) {
 
         Form form = new Form()
                 .param(OpenIdConstant.CLIENT_ID, configuration.getClientId())

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenController.java
@@ -78,6 +78,9 @@ public class TokenController {
     @Inject
     OpenIdConfiguration configuration;
 
+    @Inject
+    JWTValidator validator;
+
     /**
      * (4) A Client makes a token request to the token endpoint and the OpenId
      * Provider responds with an ID Token and an Access Token.
@@ -140,7 +143,7 @@ public class TokenController {
 
         try {
             JWTClaimsSetVerifier jwtVerifier = new IdTokenClaimsSetVerifier(expectedNonceHash, configuration);
-            claimsSet = configuration.getJWTValidator().validateBearerToken(idToken.getTokenJWT(), jwtVerifier);
+            claimsSet = validator.validateBearerToken(idToken.getTokenJWT(), jwtVerifier);
         } finally {
             nonceController.remove(configuration, request, response);
         }
@@ -153,12 +156,11 @@ public class TokenController {
      *
      * @param previousIdToken
      * @param newIdToken
-     * @param httpContext
      * @return JWT Claims
      */
-    public JWTClaimsSet validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken, HttpMessageContext httpContext) {
+    public JWTClaimsSet validateRefreshedIdToken(IdentityToken previousIdToken, IdentityTokenImpl newIdToken) {
         JWTClaimsSetVerifier jwtVerifier = new RefreshedIdTokenClaimsSetVerifier(previousIdToken, configuration);
-        JWTClaimsSet claimsSet = configuration.getJWTValidator().validateBearerToken(newIdToken.getTokenJWT(), jwtVerifier);
+        JWTClaimsSet claimsSet = validator.validateBearerToken(newIdToken.getTokenJWT(), jwtVerifier);
         return claimsSet;
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import fish.payara.security.openid.api.JwtClaims;
 import fish.payara.security.openid.api.Scope;
 import fish.payara.security.openid.api.OpenIdConstant;
+import fish.payara.security.openid.controller.JWTValidator;
 
 import java.util.Date;
 import java.util.Optional;
@@ -111,9 +112,9 @@ public class AccessTokenImpl implements AccessToken {
         this.tokenMinValidity = tokenMinValidity;
     }
 
-    public static AccessTokenImpl forBearerToken(OpenIdConfiguration configuration, String rawToken, JWTClaimsSetVerifier validator) throws ParseException {
+    public static AccessTokenImpl forBearerToken(OpenIdConfiguration configuration, String rawToken, JWTClaimsSetVerifier verifier, JWTValidator validator) throws ParseException {
         JWT token = JWTParser.parse(rawToken);
-        JWTClaimsSet claims = configuration.getJWTValidator().validateBearerToken(token, validator);
+        JWTClaimsSet claims = validator.validateBearerToken(token, verifier);
         return new AccessTokenImpl(token, claims, configuration.getTokenMinValidity());
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/IdentityTokenImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/IdentityTokenImpl.java
@@ -58,16 +58,16 @@ import static java.util.Objects.nonNull;
 public class IdentityTokenImpl implements IdentityToken {
 
     private final String token;
+    private final long tokenMinValidity;
 
     private final JWT tokenJWT;
 
     private JWTClaimsSet claims;
 
-    private OpenIdConfiguration configuration;
 
-    public IdentityTokenImpl(OpenIdConfiguration configuration, String token) {
-        this.configuration = configuration;
+    public IdentityTokenImpl(String token, long tokenMinValidity) {
         this.token = token;
+        this.tokenMinValidity = tokenMinValidity;
         try {
             this.tokenJWT = JWTParser.parse(token);
             this.claims = tokenJWT.getJWTClaimsSet();
@@ -76,11 +76,11 @@ public class IdentityTokenImpl implements IdentityToken {
         }
     }
 
-    private IdentityTokenImpl(OpenIdConfiguration configuration, JWT token, JWTClaimsSet verifiedClaims) {
+    private IdentityTokenImpl(JWT token, JWTClaimsSet verifiedClaims, long tokenMinValidity) {
         this.token = token.getParsedString();
         this.tokenJWT = token;
         this.claims = verifiedClaims;
-        this.configuration = configuration;
+        this.tokenMinValidity = tokenMinValidity;
     }
 
     public JWT getTokenJWT() {
@@ -123,7 +123,7 @@ public class IdentityTokenImpl implements IdentityToken {
         boolean expired = true;
         Date exp;
         if (nonNull(exp = (Date) this.getClaim(EXPIRATION_IDENTIFIER))) {
-            expired = System.currentTimeMillis() + configuration.getTokenMinValidity() > exp.getTime();
+            expired = System.currentTimeMillis() + tokenMinValidity > exp.getTime();
         } else {
             throw new IllegalStateException("Missing expiration time (exp) claim in identity token");
         }
@@ -136,6 +136,6 @@ public class IdentityTokenImpl implements IdentityToken {
     }
 
     public IdentityToken withClaims(JWTClaimsSet verifiedClaims) {
-        return new IdentityTokenImpl(configuration, tokenJWT, verifiedClaims);
+        return new IdentityTokenImpl(tokenJWT, verifiedClaims, tokenMinValidity);
     }
 }

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
+import fish.payara.security.openid.controller.JWTValidator;
+
 /**
  * OpenId Connect client configuration
  *
@@ -274,10 +276,4 @@ public class OpenIdConfiguration {
                 + '}';
     }
 
-    public JWTValidator getJWTValidator() {
-        if (this.validator == null) {
-            this.validator = new JWTValidator(this);
-        }
-        return this.validator;
-    }
 }

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -215,7 +215,7 @@ public class OpenIdContextImpl implements OpenIdContext {
             redirect(response, logout.buildRedirectURI(request));
         } else {
             // Redirect user to OpenID connect provider for re-authentication
-            authenticationController.authenticateUser(configuration, request, response);
+            authenticationController.authenticateUser(request, response);
         }
     }
 


### PR DESCRIPTION
The refactorings make `OpenIdConfiguration` injectable and remove it from method parameters and value objects, such as `AccessTokenCredential`.

This allows application to validate a token in obtains over other channels against current open id provider:

```
    @Inject
    IdentityStoreHandler identityStoreHandler;

    @GET
    @Path("authorize/{token}")
    public Map<String, Object> decodeToken(@PathParam("token") String accessToken) {
        var tokenCredential = new AccessTokenCredential(accessToken);
        var validationResult = identityStoreHandler.validate(tokenCredential);
        if (validationResult.getStatus() != CredentialValidationResult.Status.VALID) {
            throw new ForbiddenException("Invalid token");
        }
        var principal = (AccessTokenCallerPrincipal) validationResult.getCallerPrincipal();
        return principal.getAccessToken().getClaims();
    }
```

`ConfigurationController` contains preparatory work for per-request configuration, where it produces per-request `OpenIdConfiguration` based on injected `OpenIdAuthenticationDefinition`. So far it uses simple one-item cache, but adds class that can be used as map key later to accomodate more complicated use cases. 

`JWTValidator` was moved outside of `OpenIdConfiguration` and uses the kind of caching that would make sense for per-request configuration caching. It picks relevant literal attributes from configuration that define where the remote resources are and how to fetch them and caches according to that.