### PR TITLE
Set maven-bundle-plugin to 4.1.0 to match that of Payara server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.1</version>
+                    <version>4.1.0</version>
                     <extensions>true</extensions>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Version 5 of the plugin changes the format and is incompatible, and requires more work to upgrade than just that of updating the version number in Payara.