### PR TITLE
FISH-394: Fix support for Access Token authentication after changes

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -45,7 +45,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Typed;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -65,20 +68,19 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 @Typed(AccessTokenIdentityStore.class)
 public class AccessTokenIdentityStore implements IdentityStore {
     private static final Logger LOGGER = Logger.getLogger(AccessTokenIdentityStore.class.getName());
+    @Inject
+    OpenIdContextImpl context;
+    @Inject
+    OpenIdConfiguration configuration;
+    @Inject
+    JWTValidator validator;
+    @Inject
+    BeanManager beanManager;
 
     @Override
     public Set<ValidationType> validationTypes() {
         return Collections.singleton(ValidationType.VALIDATE);
     }
-
-    @Inject
-    OpenIdContextImpl context;
-
-    @Inject
-    OpenIdConfiguration configuration;
-
-    @Inject
-    JWTValidator validator;
 
     @SuppressWarnings("unused")
     public CredentialValidationResult validate(AccessTokenCredential credential) {
@@ -86,21 +88,33 @@ public class AccessTokenIdentityStore implements IdentityStore {
             AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(configuration,
                     credential.getAccessToken(),
                     new BearerVerifier(configuration), validator);
-            context.setAccessToken(accessToken);
-            // for setClaims we'd need to invoke userinfo. That should be lazy unless required
-            context.setCallerName(
-                    // use configured caller name claim if present in access token
-                    accessToken.getJwtClaims().getStringClaim(
-                            configuration.getClaimsConfiguration().getCallerNameClaim())
-                            // or subject, which is more likely present, but is still optional per JWT spec
-                            .orElse(accessToken.getJwtClaims().getSubject()
-                                    .orElse(null)));
+
+            // OpenIdContext is session scoped, but access tokens might be validated outside of HTTP session
+            if (isSessionActive()) {
+                context.setAccessToken(accessToken);
+                // for setClaims we'd need to invoke userinfo. That should be lazy unless required
+                context.setCallerName(
+                        // use configured caller name claim if present in access token
+                        accessToken.getJwtClaims().getStringClaim(
+                                configuration.getClaimsConfiguration().getCallerNameClaim())
+                                // or subject, which is more likely present, but is still optional per JWT spec
+                                .orElse(accessToken.getJwtClaims().getSubject()
+                                        .orElse(null)));
+            }
 
             return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken, context::getClaims));
         } catch (ParseException | RuntimeException e) {
-            LOGGER.log(Level.WARNING, "Cannot parse access token", e);
+            LOGGER.log(Level.WARNING, "Cannot parse access token " + credential.getAccessToken(), e);
         }
         return CredentialValidationResult.INVALID_RESULT;
+    }
+
+    private boolean isSessionActive() {
+        try {
+            return beanManager.getContext(SessionScoped.class).isActive();
+        } catch (ContextNotActiveException notActive) {
+            return false;
+        }
     }
 
     static class BearerVerifier extends TokenClaimsSetVerifier {

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -45,6 +45,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -61,6 +62,7 @@ import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdContextImpl;
 
 @ApplicationScoped
+@Typed(AccessTokenIdentityStore.class)
 public class AccessTokenIdentityStore implements IdentityStore {
     private static final Logger LOGGER = Logger.getLogger(AccessTokenIdentityStore.class.getName());
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -198,7 +198,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         if (isNull(request.getUserPrincipal())) {
             LOGGER.fine("UserPrincipal is not set, authenticate user using OpenId Connect protocol.");
-            if (hasBearerAuthorization(request)) {
+            if (httpContext.isProtected() && hasBearerAuthorization(request)) {
                 return authenticateBearer(request, response, httpContext);
             }
             // User is not authenticated

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
@@ -91,6 +91,7 @@ public class OpenIdExtension implements Extension {
                 UserInfoController.class,
                 OpenIdContextImpl.class,
                 OpenIdIdentityStore.class,
+                AccessTokenIdentityStore.class,
                 OpenIdAuthenticationMechanism.class,
                 JWTValidator.class
         );
@@ -183,6 +184,7 @@ public class OpenIdExtension implements Extension {
             afterBeanDiscovery.addBean()
                     .beanClass(HttpAuthenticationMechanism.class)
                     .addType(HttpAuthenticationMechanism.class)
+                    .id(OpenIdExtension.class.getName()+"/OpenIdAuthenticationMechanism")
                     .scope(ApplicationScoped.class)
                     .produceWith(in -> in.select(OpenIdAuthenticationMechanism.class).get())
                     .disposeWith((inst,callback) -> callback.destroy(inst));
@@ -190,8 +192,17 @@ public class OpenIdExtension implements Extension {
             afterBeanDiscovery.addBean()
                     .beanClass(IdentityStore.class)
                     .addType(IdentityStore.class)
+                    .id(OpenIdExtension.class.getName()+"/OpenIdIdentityStore")
                     .scope(ApplicationScoped.class)
                     .produceWith(in -> in.select(OpenIdIdentityStore.class).get())
+                    .disposeWith((inst,callback) -> callback.destroy(inst));
+
+            afterBeanDiscovery.addBean()
+                    .beanClass(IdentityStore.class)
+                    .addType(IdentityStore.class)
+                    .id(OpenIdExtension.class.getName()+"/AccessTokenIdentityStore")
+                    .scope(ApplicationScoped.class)
+                    .produceWith(in -> in.select(AccessTokenIdentityStore.class).get())
                     .disposeWith((inst,callback) -> callback.destroy(inst));
 
             afterBeanDiscovery.addBean()

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -81,6 +81,8 @@ public class OpenIdContextImpl implements OpenIdContext {
     private RefreshToken refreshToken;
     private Long expiresIn;
     private JsonObject claims;
+
+    @Inject
     private OpenIdConfiguration configuration;
 
     @Inject
@@ -176,10 +178,6 @@ public class OpenIdContextImpl implements OpenIdContext {
     @Override
     public JsonObject getProviderMetadata() {
         return configuration.getProviderMetadata().getDocument();
-    }
-
-    public void setOpenIdConfiguration(OpenIdConfiguration configuration) {
-        this.configuration = configuration;
     }
 
     public void logout(HttpServletRequest request, HttpServletResponse response) {


### PR DESCRIPTION
AccessTokenIdentityStore added to list of extension's beans.

Produced beans need explicit type IDs otherwise the runtime can consider
them the same.

Handle different validation statuses during bearer authentication.

Use Injection for OpenIdConfiguration rather than explicit setting.