### PR TITLE
FISH-786 Finish renaming security-api to security-connectors-api

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.security.connectors</groupId>
-            <artifactId>security-api</artifactId>
+            <artifactId>security-connectors-api</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.security.connectors</groupId>
-            <artifactId>security-api</artifactId>
+            <artifactId>security-connectors-api</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
After renaming the artifact, the dependent projects failed to build on a clean machine.