### PR TITLE
FISH-385: Evaluate OpenId configuration per session

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -45,7 +45,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Typed;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -65,20 +68,19 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 @Typed(AccessTokenIdentityStore.class)
 public class AccessTokenIdentityStore implements IdentityStore {
     private static final Logger LOGGER = Logger.getLogger(AccessTokenIdentityStore.class.getName());
+    @Inject
+    OpenIdContextImpl context;
+    @Inject
+    OpenIdConfiguration configuration;
+    @Inject
+    JWTValidator validator;
+    @Inject
+    BeanManager beanManager;
 
     @Override
     public Set<ValidationType> validationTypes() {
         return Collections.singleton(ValidationType.VALIDATE);
     }
-
-    @Inject
-    OpenIdContextImpl context;
-
-    @Inject
-    OpenIdConfiguration configuration;
-
-    @Inject
-    JWTValidator validator;
 
     @SuppressWarnings("unused")
     public CredentialValidationResult validate(AccessTokenCredential credential) {
@@ -86,21 +88,33 @@ public class AccessTokenIdentityStore implements IdentityStore {
             AccessTokenImpl accessToken = AccessTokenImpl.forBearerToken(configuration,
                     credential.getAccessToken(),
                     new BearerVerifier(configuration), validator);
-            context.setAccessToken(accessToken);
-            // for setClaims we'd need to invoke userinfo. That should be lazy unless required
-            context.setCallerName(
-                    // use configured caller name claim if present in access token
-                    accessToken.getJwtClaims().getStringClaim(
-                            configuration.getClaimsConfiguration().getCallerNameClaim())
-                            // or subject, which is more likely present, but is still optional per JWT spec
-                            .orElse(accessToken.getJwtClaims().getSubject()
-                                    .orElse(null)));
+
+            // OpenIdContext is session scoped, but access tokens might be validated outside of HTTP session
+            if (isSessionActive()) {
+                context.setAccessToken(accessToken);
+                // for setClaims we'd need to invoke userinfo. That should be lazy unless required
+                context.setCallerName(
+                        // use configured caller name claim if present in access token
+                        accessToken.getJwtClaims().getStringClaim(
+                                configuration.getClaimsConfiguration().getCallerNameClaim())
+                                // or subject, which is more likely present, but is still optional per JWT spec
+                                .orElse(accessToken.getJwtClaims().getSubject()
+                                        .orElse(null)));
+            }
 
             return new CredentialValidationResult(new AccessTokenCallerPrincipal(accessToken, context::getClaims));
         } catch (ParseException | RuntimeException e) {
-            LOGGER.log(Level.WARNING, "Cannot parse access token", e);
+            LOGGER.log(Level.WARNING, "Cannot parse access token " + credential.getAccessToken(), e);
         }
         return CredentialValidationResult.INVALID_RESULT;
+    }
+
+    private boolean isSessionActive() {
+        try {
+            return beanManager.getContext(SessionScoped.class).isActive();
+        } catch (ContextNotActiveException notActive) {
+            return false;
+        }
     }
 
     static class BearerVerifier extends TokenClaimsSetVerifier {

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -45,6 +45,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
@@ -61,6 +62,7 @@ import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdContextImpl;
 
 @ApplicationScoped
+@Typed(AccessTokenIdentityStore.class)
 public class AccessTokenIdentityStore implements IdentityStore {
     private static final Logger LOGGER = Logger.getLogger(AccessTokenIdentityStore.class.getName());
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -198,7 +198,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         if (isNull(request.getUserPrincipal())) {
             LOGGER.fine("UserPrincipal is not set, authenticate user using OpenId Connect protocol.");
-            if (hasBearerAuthorization(request)) {
+            if (httpContext.isProtected() && hasBearerAuthorization(request)) {
                 return authenticateBearer(request, response, httpContext);
             }
             // User is not authenticated

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
@@ -91,6 +91,7 @@ public class OpenIdExtension implements Extension {
                 UserInfoController.class,
                 OpenIdContextImpl.class,
                 OpenIdIdentityStore.class,
+                AccessTokenIdentityStore.class,
                 OpenIdAuthenticationMechanism.class,
                 JWTValidator.class
         );
@@ -183,6 +184,7 @@ public class OpenIdExtension implements Extension {
             afterBeanDiscovery.addBean()
                     .beanClass(HttpAuthenticationMechanism.class)
                     .addType(HttpAuthenticationMechanism.class)
+                    .id(OpenIdExtension.class.getName()+"/OpenIdAuthenticationMechanism")
                     .scope(ApplicationScoped.class)
                     .produceWith(in -> in.select(OpenIdAuthenticationMechanism.class).get())
                     .disposeWith((inst,callback) -> callback.destroy(inst));
@@ -190,8 +192,17 @@ public class OpenIdExtension implements Extension {
             afterBeanDiscovery.addBean()
                     .beanClass(IdentityStore.class)
                     .addType(IdentityStore.class)
+                    .id(OpenIdExtension.class.getName()+"/OpenIdIdentityStore")
                     .scope(ApplicationScoped.class)
                     .produceWith(in -> in.select(OpenIdIdentityStore.class).get())
+                    .disposeWith((inst,callback) -> callback.destroy(inst));
+
+            afterBeanDiscovery.addBean()
+                    .beanClass(IdentityStore.class)
+                    .addType(IdentityStore.class)
+                    .id(OpenIdExtension.class.getName()+"/AccessTokenIdentityStore")
+                    .scope(ApplicationScoped.class)
+                    .produceWith(in -> in.select(AccessTokenIdentityStore.class).get())
                     .disposeWith((inst,callback) -> callback.destroy(inst));
 
             afterBeanDiscovery.addBean()

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdExtension.java
@@ -182,7 +182,7 @@ public class OpenIdExtension implements Extension {
         boolean sessionScopedConfig = false;
         try {
             sessionScopedConfig = mpConfig.getOptionalValue(OpenIdAuthenticationDefinition.OPENID_MP_SESSION_SCOPED_CONFIGURATION, boolean.class)
-                    .orElse(true);
+                    .orElse(false);
         } catch (IllegalArgumentException e) {
             LOGGER.warning("The value of " + OpenIdAuthenticationDefinition.OPENID_MP_SESSION_SCOPED_CONFIGURATION + "is not a boolean value. The OpenID connector will be configured only once for all requests.");
         }

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -44,6 +44,8 @@ import fish.payara.security.openid.domain.ClaimsConfiguration;
 import fish.payara.security.openid.domain.LogoutConfiguration;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdTokenEncryptionMetadata;
+
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -76,18 +78,21 @@ import org.eclipse.microprofile.config.ConfigProvider;
  * @author Gaurav Gupta
  */
 @ApplicationScoped
-public class ConfigurationController {
+public class ConfigurationController implements Serializable {
 
     @Inject
     private ProviderMetadataContoller providerMetadataContoller;
 
     private static final String SPACE_SEPARATOR = " ";
 
-    private volatile LastBuiltConfig lastBuiltConfig = new LastBuiltConfig(null, null);
+    private volatile transient LastBuiltConfig lastBuiltConfig;
 
     @Produces
     @RequestScoped
     public OpenIdConfiguration produceConfiguration(OpenIdAuthenticationDefinition definition) {
+        if (lastBuiltConfig == null) {
+            lastBuiltConfig = new LastBuiltConfig(null, null);
+        }
         OpenIdConfiguration cached = lastBuiltConfig.cachedConfiguration(definition);
         if (cached != null) {
             return cached;

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -81,6 +81,8 @@ public class OpenIdContextImpl implements OpenIdContext {
     private RefreshToken refreshToken;
     private Long expiresIn;
     private JsonObject claims;
+
+    @Inject
     private OpenIdConfiguration configuration;
 
     @Inject
@@ -176,10 +178,6 @@ public class OpenIdContextImpl implements OpenIdContext {
     @Override
     public JsonObject getProviderMetadata() {
         return configuration.getProviderMetadata().getDocument();
-    }
-
-    public void setOpenIdConfiguration(OpenIdConfiguration configuration) {
-        this.configuration = configuration;
     }
 
     public void logout(HttpServletRequest request, HttpServletResponse response) {

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -355,4 +355,8 @@ public @interface OpenIdAuthenticationDefinition {
      */
     String OPENID_MP_TOKEN_MIN_VALIDITY = "payara.security.openid.token.minValidity";
 
+    /**
+     * The Microprofile Config key for evaluating EL expressions for every HTTP session is <code>{@value}</code>
+     */
+    String OPENID_MP_SESSION_SCOPED_CONFIGURATION = "payara.security.openid.sessionScopedConfiguration";
 }


### PR DESCRIPTION
This is based on #82, merging that one will make the diff much slimmer, the implementation of the feature is actually just the last commit.

This is one of the possible implementations for supporting non-static (evaluated once per configuration) OpenIdConfigurationDefinition.

If MP Config property `payara.security.openid.sessionScopedConfiguration` is set to true, then OpenID connector is configured per session. That means that different users can authenticate using a different OIDC provider and configuration.