### PR TITLE
FISH-1370 Fix class leak when app is redeployed

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -59,6 +59,7 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import javax.security.enterprise.credential.Credential;
 
 /**
  * Identity store validates the identity token & access toekn and returns the
@@ -109,6 +110,15 @@ public class OpenIdIdentityStore implements IdentityStore {
                 context.getCallerName(),
                 context.getCallerGroups()
         );
+    }
+    
+    @Override
+    public CredentialValidationResult validate(Credential credential) {
+        if (credential instanceof OpenIdCredential) {
+            return validate((OpenIdCredential) credential);
+        } else {
+            return CredentialValidationResult.NOT_VALIDATED_RESULT;
+        }
     }
 
     private String getCallerName() {


### PR DESCRIPTION
When app with the standalone connector was redeployed, 
the connector classes in the new app clashed with the ones kept in 
the parent classloader:

```
Caused by: java.lang.IllegalAccessException: no such method: fish.payara.security.connectors.openid.OpenIdIdentityStore.validate(OpenIdCredential)CredentialValidationResult/invokeSpecial
    at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:959)
    at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1101)
    at java.base/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:2030)
    at java.base/java.lang.invoke.MethodHandles$Lookup.bind(MethodHandles.java:1694)
    at javax.security.enterprise.identitystore.IdentityStore.validate(IdentityStore.java:84)
    ... 53 more
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method 'javax.security.enterprise.identitystore.CredentialValidationResult fish.payara.security.connectors.openid.OpenIdIdentityStore.validate(fish.payara.security.connectors.openid.OpenIdCredential)' the class loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @16c28c00 of the current class, javax/security/enterprise/identitystore/IdentityStore, and the class loader org.glassfish.web.loader.WebappClassLoader @10328a88 for the method's defining class, fish/payara/security/connectors/openid/OpenIdIdentityStore, have different Class objects for the type fish/payara/security/connectors/openid/OpenIdCredential used in the signature (javax.security.enterprise.identitystore.IdentityStore is in unnamed module of loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @16c28c00, parent loader java.net.URLClassLoader @369f73a2; fish.payara.security.connectors.openid.OpenIdIdentityStore is in unnamed module of loader org.glassfish.web.loader.WebappClassLoader @10328a88, parent loader org.glassfish.internal.api.DelegatingClassLoader @13735c24)
    at java.base/java.lang.invoke.MethodHandleNatives.resolve(Native Method)
    at java.base/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:1070)
    at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1098)
```