### PR TITLE
FISH-786: Support both MP 3.3. and 4.0+ in OSGi

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -92,16 +92,13 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Import-Package>
-                            !org.eclipse.microprofile.*,
                             org.eclipse.microprofile.config;version="[1.0,3)",
                             *
                         </Import-Package>
                         <Export-Package>
-                            !org.eclipse.microprofile.*,
                             fish.payara.security.oauth2.*
                         </Export-Package>
                     </instructions>
-                    <excludeDependencies>microprofile,microprofile-config-api</excludeDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -91,7 +91,17 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Import-Package>
+                            !org.eclipse.microprofile.*,
+                            org.eclipse.microprofile.config;version="[1.0,3)",
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            !org.eclipse.microprofile.*,
+                            fish.payara.security.oauth2.*
+                        </Export-Package>
                     </instructions>
+                    <excludeDependencies>microprofile,microprofile-config-api</excludeDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -125,14 +125,13 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>
-                            !org.eclipse.microprofile.*,
                             fish.payara.security.openid.*
                         </Export-Package>
                         <!-- Import API classes, other are NimbusDS optional dependencies -->
                         <Import-Package>
-                            javax.*, fish.payara.*, !org.eclipse.microprofile.*,
-                            *;resolution:=optional, org.eclipse.microprofile.config;v
- ersion="[1.0,3)"
+                            javax.*, fish.payara.*, 
+                            org.eclipse.microprofile.config;version="[1.0,3)", 
+                            org.eclipse.*, *;resolution:=optional
                         </Import-Package>
                         <!-- Package NimbusDS with the connector, so that server doesn't need to
                              distribute it explicitly -->
@@ -140,7 +139,6 @@
                             jcip-annotations;inline=true</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
-                    <excludeDependencies>microprofile,microprofile-config-api</excludeDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -125,12 +125,14 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>
+                            !org.eclipse.microprofile.*,
                             fish.payara.security.openid.*
                         </Export-Package>
                         <!-- Import API classes, other are NimbusDS optional dependencies -->
                         <Import-Package>
-                            javax.*, fish.payara.*, org.eclipse.*,
-                            *;resolution:=optional
+                            javax.*, fish.payara.*, !org.eclipse.microprofile.*,
+                            *;resolution:=optional, org.eclipse.microprofile.config;v
+ ersion="[1.0,3)"
                         </Import-Package>
                         <!-- Package NimbusDS with the connector, so that server doesn't need to
                              distribute it explicitly -->
@@ -138,6 +140,7 @@
                             jcip-annotations;inline=true</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
+                    <excludeDependencies>microprofile,microprofile-config-api</excludeDependencies>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Don't export MP packages. Allow to import MP Config 
from version 1.4 (MP 3.3) to 2.0+ (MP 4.0+)

This is needed to integrate to the latest Payara Enterprise.