### PR TITLE
FISH-1521: Fix for parsing groups from JWT token

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -59,6 +59,8 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.security.enterprise.credential.Credential;
 
 /**
@@ -69,6 +71,8 @@ import javax.security.enterprise.credential.Credential;
  */
 @ApplicationScoped
 public class OpenIdIdentityStore implements IdentityStore {
+
+    private static final Logger LOGGER = Logger.getLogger(OpenIdIdentityStore.class.getName());
 
     @Inject
     private OpenIdContextImpl context;
@@ -103,8 +107,17 @@ public class OpenIdIdentityStore implements IdentityStore {
             context.setAccessToken(accessToken);
         }
 
-        context.setCallerName(getCallerName());
-        context.setCallerGroups(getCallerGroups());
+        String callerName = getCallerName();
+        context.setCallerName(callerName);
+        Set<String> callerGroups = getCallerGroups();
+        context.setCallerGroups(callerGroups);
+        
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Setting caller groups into the OpenID context: " + callerGroups);
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(Level.FINER, "Setting caller name into the OpenID context: " + callerName);
+            }
+        }
 
         return new CredentialValidationResult(
                 context.getCallerName(),

--- a/openid/src/main/java/fish/payara/security/openid/domain/JsonClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/JsonClaims.java
@@ -79,18 +79,25 @@ class JsonClaims implements OpenIdClaims {
         if (value == null) {
             return Collections.emptyList();
         }
-        if (value.getValueType() == JsonValue.ValueType.STRING) {
-            return Collections.singletonList(getStringValue(value));
-        }
         if (value.getValueType() == JsonValue.ValueType.ARRAY) {
             return value.asJsonArray().stream().map(this::getStringValue).collect(Collectors.toList());
         }
-        throw new IllegalArgumentException("Cannot interpret "+name+" as string array");
+        return Collections.singletonList(getStringValue(value));
     }
 
     private String getStringValue(JsonValue value) {
-            JsonString stringValue = (JsonString)value;
-            return stringValue.getString();
+        switch (value.getValueType()) {
+            case STRING:
+                return ((JsonString)value).getString();
+            case TRUE:
+                return "true";
+            case FALSE:
+                return "false";
+            case NUMBER:
+                return ((JsonNumber)value).numberValue().toString();
+            default:
+                throw new IllegalArgumentException("Cannot handle nested JSON value in a claim:" + value);
+        }
     }
     
     private JsonNumber getNumber(String name) {

--- a/openid/src/main/java/fish/payara/security/openid/domain/JsonClaims.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/JsonClaims.java
@@ -53,6 +53,7 @@ import javax.json.JsonValue;
 
 import fish.payara.security.openid.api.Claims;
 import fish.payara.security.openid.api.OpenIdClaims;
+import javax.json.JsonString;
 
 class JsonClaims implements OpenIdClaims {
     private final JsonObject claims;
@@ -79,14 +80,19 @@ class JsonClaims implements OpenIdClaims {
             return Collections.emptyList();
         }
         if (value.getValueType() == JsonValue.ValueType.STRING) {
-            return Collections.singletonList(value.toString());
+            return Collections.singletonList(getStringValue(value));
         }
         if (value.getValueType() == JsonValue.ValueType.ARRAY) {
-            return value.asJsonArray().stream().map(JsonValue::toString).collect(Collectors.toList());
+            return value.asJsonArray().stream().map(this::getStringValue).collect(Collectors.toList());
         }
         throw new IllegalArgumentException("Cannot interpret "+name+" as string array");
     }
 
+    private String getStringValue(JsonValue value) {
+            JsonString stringValue = (JsonString)value;
+            return stringValue.getString();
+    }
+    
     private JsonNumber getNumber(String name) {
         try {
             return claims.getJsonNumber(name);


### PR DESCRIPTION
Previously, it converted a group string into a string or strings that contain enclosing quotes in group name. This PR retrieves only the group names, without quotes in the string.