### PR TITLE
FISH-5743 FISH-5741 define oicd metadata locally

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationException.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.openid;
+
+/**
+ * Exception thrown during @OpenIdAuthenticationDefinition processing.
+ *
+ * @author Petr Aubrecht <petr@aubrecht.net>
+ */
+public class OpenIdAuthenticationException extends RuntimeException {
+
+    public OpenIdAuthenticationException(String message) {
+        super(message);
+    }
+
+    public OpenIdAuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -67,7 +67,6 @@ import fish.payara.security.annotations.ClaimsDefinition;
 import fish.payara.security.annotations.LogoutDefinition;
 import fish.payara.security.openid.OpenIdUtil;
 import fish.payara.security.openid.api.OpenIdConstant;
-import java.util.Collections;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -115,47 +114,50 @@ public class ConfigurationController implements Serializable {
 
         String providerURI;
         JsonObject providerDocument;
+        String issuerURI;
         String authorizationEndpoint;
         String tokenEndpoint;
         String userinfoEndpoint;
         String endSessionEndpoint;
         String jwksURI;
         URL jwksURL;
+        Set<String> scopesSupported;
+        Set<String> responseTypesSupported;
+        Set<String> subjectTypesSupported;
+        Set<String> idTokenSigningAlgValuesSupported;
+        Set<String> idTokenEncryptionAlgValuesSupported;
+        Set<String> idTokenEncryptionEncValuesSupported;
+        Set<String> claimsSupported;
 
         providerURI = OpenIdUtil.getConfiguredValue(String.class, definition.providerURI(), provider, OpenIdAuthenticationDefinition.OPENID_MP_PROVIDER_URI);
         fish.payara.security.annotations.OpenIdProviderMetadata providerMetadata = definition.providerMetadata();
         providerDocument = providerMetadataContoller.getDocument(providerURI);
 
-        if (OpenIdUtil.isEmpty(providerMetadata.authorizationEndpoint()) && providerDocument.containsKey(OpenIdConstant.AUTHORIZATION_ENDPOINT)) {
-            authorizationEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.AUTHORIZATION_ENDPOINT), provider, OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT);
-        } else {
-            authorizationEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.authorizationEndpoint(), provider, OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT);
+        // collect metadata either from the metadata annotation or from the autoconfiguration providerDocument
+        issuerURI = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.issuer(), providerDocument, OpenIdConstant.ISSUER, provider, OpenIdProviderMetadata.OPENID_MP_ISSUER);
+
+        if (issuerURI == null || "".equals(issuerURI)) {
+            throw new IllegalStateException("issuer URL is not available, specify it either in @OpenIdProviderMetadata or by providerURI and autoconfiguration");
         }
-        if (OpenIdUtil.isEmpty(providerMetadata.tokenEndpoint()) && providerDocument.containsKey(OpenIdConstant.TOKEN_ENDPOINT)) {
-            tokenEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.TOKEN_ENDPOINT), provider, OpenIdProviderMetadata.OPENID_MP_TOKEN_ENDPOINT);
-        } else {
-            tokenEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.tokenEndpoint(), provider, OpenIdProviderMetadata.OPENID_MP_TOKEN_ENDPOINT);
-        }
-        if (OpenIdUtil.isEmpty(providerMetadata.userinfoEndpoint()) && providerDocument.containsKey(OpenIdConstant.USERINFO_ENDPOINT)) {
-            userinfoEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.USERINFO_ENDPOINT), provider, OpenIdProviderMetadata.OPENID_MP_USERINFO_ENDPOINT);
-        } else {
-            userinfoEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.userinfoEndpoint(), provider, OpenIdProviderMetadata.OPENID_MP_USERINFO_ENDPOINT);
-        }
-        if (OpenIdUtil.isEmpty(providerMetadata.endSessionEndpoint()) && providerDocument.containsKey(OpenIdConstant.END_SESSION_ENDPOINT)) {
-            endSessionEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.END_SESSION_ENDPOINT), provider, OpenIdProviderMetadata.OPENID_MP_END_SESSION_ENDPOINT);
-        } else {
-            endSessionEndpoint = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.endSessionEndpoint(), provider, OpenIdProviderMetadata.OPENID_MP_END_SESSION_ENDPOINT);
-        }
-        if (OpenIdUtil.isEmpty(providerMetadata.jwksURI()) && providerDocument.containsKey(OpenIdConstant.JWKS_URI)) {
-            jwksURI = OpenIdUtil.getConfiguredValue(String.class, providerDocument.getString(OpenIdConstant.JWKS_URI), provider, OpenIdProviderMetadata.OPENID_MP_JWKS_URI);
-        } else {
-            jwksURI = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.jwksURI(), provider, OpenIdProviderMetadata.OPENID_MP_JWKS_URI);
-        }
+
+        authorizationEndpoint = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.authorizationEndpoint(), providerDocument, OpenIdConstant.AUTHORIZATION_ENDPOINT, provider, OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT);
+        tokenEndpoint = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.tokenEndpoint(), providerDocument, OpenIdConstant.TOKEN_ENDPOINT, provider, OpenIdProviderMetadata.OPENID_MP_TOKEN_ENDPOINT);
+        userinfoEndpoint = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.userinfoEndpoint(), providerDocument, OpenIdConstant.USERINFO_ENDPOINT, provider, OpenIdProviderMetadata.OPENID_MP_USERINFO_ENDPOINT);
+        endSessionEndpoint = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.endSessionEndpoint(), providerDocument, OpenIdConstant.END_SESSION_ENDPOINT, provider, OpenIdProviderMetadata.OPENID_MP_END_SESSION_ENDPOINT);
+        jwksURI = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.jwksURI(), providerDocument, OpenIdConstant.JWKS_URI, provider, OpenIdProviderMetadata.OPENID_MP_JWKS_URI);
         try {
             jwksURL = new URL(jwksURI);
         } catch (MalformedURLException ex) {
-            throw new IllegalStateException("jwksURI is invalid", ex);
+            throw new IllegalStateException("jwksURI is not a valid URL: " + jwksURI, ex);
         }
+        scopesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.scopesSupported(), providerDocument, OpenIdConstant.SCOPES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_SCOPES_SUPPORTED);
+        responseTypesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.responseTypesSupported(), providerDocument, OpenIdConstant.RESPONSE_TYPES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_RESPONSE_TYPES_SUPPORTED);
+        subjectTypesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.subjectTypesSupported(), providerDocument, OpenIdConstant.SUBJECT_TYPES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_SUBJECT_TYPES_SUPPORTED);
+        idTokenSigningAlgValuesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.idTokenSigningAlgValuesSupported(), providerDocument, OpenIdConstant.ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED);
+        idTokenEncryptionAlgValuesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.idTokenEncryptionAlgValuesSupported(), providerDocument, OpenIdConstant.ID_TOKEN_ENCRYPTION_ALG_VALUES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_ID_TOKEN_ENCRYPTION_ALG_VALUES_SUPPORTED);
+        idTokenEncryptionEncValuesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.idTokenEncryptionEncValuesSupported(), providerDocument, OpenIdConstant.ID_TOKEN_ENCRYPTION_ENC_VALUES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_ID_TOKEN_ENCRYPTION_ENC_VALUES_SUPPORTED);
+        claimsSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.claimsSupported(), providerDocument, OpenIdConstant.CLAIMS_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_CLAIMS_SUPPORTED);
+
         String clientId = OpenIdUtil.getConfiguredValue(String.class, definition.clientId(), provider, OpenIdAuthenticationDefinition.OPENID_MP_CLIENT_ID);
         char[] clientSecret = OpenIdUtil.getConfiguredValue(String.class, definition.clientSecret(), provider, OpenIdAuthenticationDefinition.OPENID_MP_CLIENT_SECRET).toCharArray();
         String redirectURI = OpenIdUtil.getConfiguredValue(String.class, definition.redirectURI(), provider, OpenIdAuthenticationDefinition.OPENID_MP_REDIRECT_URI);
@@ -194,8 +196,8 @@ public class ConfigurationController implements Serializable {
             extraParameters.put(key, value);
         }
 
-        boolean nonce = OpenIdUtil.getConfiguredValue(Boolean.class, definition.useNonce(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE);
-        boolean session = OpenIdUtil.getConfiguredValue(Boolean.class, definition.useSession(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION);
+        boolean useNonce = OpenIdUtil.getConfiguredValue(Boolean.class, definition.useNonce(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USE_NONCE);
+        boolean useSession = OpenIdUtil.getConfiguredValue(Boolean.class, definition.useSession(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION);
 
         int jwksConnectTimeout = OpenIdUtil.getConfiguredValue(Integer.class, definition.jwksConnectTimeout(), provider, OpenIdAuthenticationDefinition.OPENID_MP_JWKS_CONNECT_TIMEOUT);
         int jwksReadTimeout = OpenIdUtil.getConfiguredValue(Integer.class, definition.jwksReadTimeout(), provider, OpenIdAuthenticationDefinition.OPENID_MP_JWKS_READ_TIMEOUT);
@@ -216,30 +218,25 @@ public class ConfigurationController implements Serializable {
         int tokenMinValidity = OpenIdUtil.getConfiguredValue(Integer.class, definition.tokenMinValidity(), provider, OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_MIN_VALIDITY);
         boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
 
-        fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata;
-        if (providerDocument != null) {
-            openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(providerDocument);
-        } else {
-            // FIXME: necessary to provide meaningful default data
-            openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
-                    null,
-                    Collections.emptySet(),
-                    Collections.emptySet(),
-                    Collections.emptySet(),
-                    Collections.emptySet(),
-                    Collections.emptySet(),
-                    Collections.emptySet(),
-                    Collections.emptySet());
-        }
+        fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
+                providerDocument,
+                issuerURI,
+                scopesSupported,
+                claimsSupported,
+                responseTypesSupported,
+                idTokenSigningAlgValuesSupported,
+                idTokenEncryptionAlgValuesSupported,
+                idTokenEncryptionEncValuesSupported,
+                subjectTypesSupported)
+                .setAuthorizationEndpoint(authorizationEndpoint)
+                .setTokenEndpoint(tokenEndpoint)
+                .setUserinfoEndpoint(userinfoEndpoint)
+                .setEndSessionEndpoint(endSessionEndpoint)
+                .setJwksURL(jwksURL);
 
         OpenIdConfiguration configuration = new OpenIdConfiguration()
                 .setProviderMetadata(
                         openIdProviderMetadata
-                                .setAuthorizationEndpoint(authorizationEndpoint)
-                                .setTokenEndpoint(tokenEndpoint)
-                                .setUserinfoEndpoint(userinfoEndpoint)
-                                .setEndSessionEndpoint(endSessionEndpoint)
-                                .setJwksURL(jwksURL)
                 )
                 .setClaimsConfiguration(
                         new ClaimsConfiguration()
@@ -267,8 +264,8 @@ public class ConfigurationController implements Serializable {
                 .setExtraParameters(extraParameters)
                 .setPrompt(prompt)
                 .setDisplay(display)
-                .setUseNonce(nonce)
-                .setUseSession(session)
+                .setUseNonce(useNonce)
+                .setUseSession(useSession)
                 .setJwksConnectTimeout(jwksConnectTimeout)
                 .setJwksReadTimeout(jwksReadTimeout)
                 .setTokenAutoRefresh(tokenAutoRefresh)
@@ -296,10 +293,18 @@ public class ConfigurationController implements Serializable {
 
     private List<String> validateProviderMetadata(OpenIdConfiguration configuration) {
         List<String> errorMessages = new ArrayList<>();
+        String issuerURI = configuration.getProviderMetadata().getIssuerURI();
 
-        if (OpenIdUtil.isEmpty(configuration.getProviderMetadata().getIssuerURI())) {
+        if (OpenIdUtil.isEmpty(issuerURI)) {
             errorMessages.add("issuer metadata is mandatory");
         }
+        try {
+            // only try to parse issuerURI
+            new URL(issuerURI);
+        } catch (MalformedURLException ex) {
+            errorMessages.add("issuer metadata is not a valid URL: " + ex.getMessage());
+        }
+
         if (OpenIdUtil.isEmpty(configuration.getProviderMetadata().getAuthorizationEndpoint())) {
             errorMessages.add("authorization_endpoint metadata is mandatory");
         }
@@ -309,13 +314,13 @@ public class ConfigurationController implements Serializable {
         if (configuration.getProviderMetadata().getJwksURL() == null) {
             errorMessages.add("jwks_uri metadata is mandatory");
         }
-        if (configuration.getProviderMetadata().getResponseTypeSupported().isEmpty()) {
+        if (configuration.getProviderMetadata().getResponseTypesSupported().isEmpty()) {
             errorMessages.add("response_types_supported metadata is mandatory");
         }
-        if (configuration.getProviderMetadata().getResponseTypeSupported().isEmpty()) {
+        if (configuration.getProviderMetadata().getResponseTypesSupported().isEmpty()) {
             errorMessages.add("subject_types_supported metadata is mandatory");
         }
-        if (configuration.getProviderMetadata().getIdTokenSigningAlgorithmsSupported().isEmpty()) {
+        if (configuration.getProviderMetadata().getIdTokenSigningAlgValuesSupported().isEmpty()) {
             errorMessages.add("id_token_signing_alg_values_supported metadata is mandatory");
         }
         return errorMessages;
@@ -339,7 +344,7 @@ public class ConfigurationController implements Serializable {
 
         if (OpenIdUtil.isEmpty(configuration.getResponseType())) {
             errorMessages.add("The response type must contain at least one value");
-        } else if (!configuration.getProviderMetadata().getResponseTypeSupported().contains(configuration.getResponseType())
+        } else if (!configuration.getProviderMetadata().getResponseTypesSupported().contains(configuration.getResponseType())
                 && !OpenIdConstant.AUTHORIZATION_CODE_FLOW_TYPES.contains(configuration.getResponseType())
                 && !OpenIdConstant.IMPLICIT_FLOW_TYPES.contains(configuration.getResponseType())
                 && !OpenIdConstant.HYBRID_FLOW_TYPES.contains(configuration.getResponseType())) {

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -137,7 +137,7 @@ public class ConfigurationController implements Serializable {
         // collect metadata either from the metadata annotation or from the autoconfiguration providerDocument
         issuerURI = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.issuer(), providerDocument, OpenIdConstant.ISSUER, provider, OpenIdProviderMetadata.OPENID_MP_ISSUER);
 
-        if (issuerURI == null || "".equals(issuerURI)) {
+        if (issuerURI == null || issuerURI.isEmpty()) {
             throw new OpenIdAuthenticationException("issuer URL is not available, specify it either in @OpenIdProviderMetadata or by providerURI and autoconfiguration");
         }
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -53,9 +53,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
@@ -69,6 +67,7 @@ import fish.payara.security.annotations.ClaimsDefinition;
 import fish.payara.security.annotations.LogoutDefinition;
 import fish.payara.security.openid.OpenIdUtil;
 import fish.payara.security.openid.api.OpenIdConstant;
+import java.util.Collections;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -217,9 +216,25 @@ public class ConfigurationController implements Serializable {
         int tokenMinValidity = OpenIdUtil.getConfiguredValue(Integer.class, definition.tokenMinValidity(), provider, OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_MIN_VALIDITY);
         boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
 
+        fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata;
+        if (providerDocument != null) {
+            openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(providerDocument);
+        } else {
+            // FIXME: necessary to provide meaningful default data
+            openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
+                    null,
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet());
+        }
+
         OpenIdConfiguration configuration = new OpenIdConfiguration()
                 .setProviderMetadata(
-                        new fish.payara.security.openid.domain.OpenIdProviderMetadata(providerDocument)
+                        openIdProviderMetadata
                                 .setAuthorizationEndpoint(authorizationEndpoint)
                                 .setTokenEndpoint(tokenEndpoint)
                                 .setUserinfoEndpoint(userinfoEndpoint)

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -65,6 +65,7 @@ import javax.json.JsonObject;
 
 import fish.payara.security.annotations.ClaimsDefinition;
 import fish.payara.security.annotations.LogoutDefinition;
+import fish.payara.security.openid.OpenIdAuthenticationException;
 import fish.payara.security.openid.OpenIdUtil;
 import fish.payara.security.openid.api.OpenIdConstant;
 import org.eclipse.microprofile.config.Config;
@@ -137,7 +138,7 @@ public class ConfigurationController implements Serializable {
         issuerURI = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.issuer(), providerDocument, OpenIdConstant.ISSUER, provider, OpenIdProviderMetadata.OPENID_MP_ISSUER);
 
         if (issuerURI == null || "".equals(issuerURI)) {
-            throw new IllegalStateException("issuer URL is not available, specify it either in @OpenIdProviderMetadata or by providerURI and autoconfiguration");
+            throw new OpenIdAuthenticationException("issuer URL is not available, specify it either in @OpenIdProviderMetadata or by providerURI and autoconfiguration");
         }
 
         authorizationEndpoint = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.authorizationEndpoint(), providerDocument, OpenIdConstant.AUTHORIZATION_ENDPOINT, provider, OpenIdProviderMetadata.OPENID_MP_AUTHORIZATION_ENDPOINT);
@@ -148,7 +149,7 @@ public class ConfigurationController implements Serializable {
         try {
             jwksURL = new URL(jwksURI);
         } catch (MalformedURLException ex) {
-            throw new IllegalStateException("jwksURI is not a valid URL: " + jwksURI, ex);
+            throw new OpenIdAuthenticationException("jwksURI is not a valid URL: " + jwksURI, ex);
         }
         scopesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.scopesSupported(), providerDocument, OpenIdConstant.SCOPES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_SCOPES_SUPPORTED);
         responseTypesSupported = OpenIdUtil.readConfiguredValueFromMetadataOrProvider(providerMetadata.responseTypesSupported(), providerDocument, OpenIdConstant.RESPONSE_TYPES_SUPPORTED, provider, OpenIdProviderMetadata.OPENID_MP_RESPONSE_TYPES_SUPPORTED);
@@ -287,7 +288,7 @@ public class ConfigurationController implements Serializable {
         errorMessages.addAll(validateClientConfiguration(configuration));
 
         if (!errorMessages.isEmpty()) {
-            throw new IllegalStateException(errorMessages.toString());
+            throw new OpenIdAuthenticationException(errorMessages.toString());
         }
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/controller/JWTValidator.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/JWTValidator.java
@@ -170,13 +170,13 @@ public class JWTValidator {
         if (isNull(jwsAlg)) {
             throw new IllegalStateException("Missing JWE encryption algorithm ");
         }
-        if (!configuration.getProviderMetadata().getIdTokenEncryptionAlgorithmsSupported().contains(jwsAlg.getName())) {
+        if (!configuration.getProviderMetadata().getIdTokenEncryptionAlgValuesSupported().contains(jwsAlg.getName())) {
             throw new IllegalStateException("Unsupported ID tokens algorithm :" + jwsAlg.getName());
         }
         if (isNull(jweEnc)) {
             throw new IllegalStateException("Missing JWE encryption method");
         }
-        if (!configuration.getProviderMetadata().getIdTokenEncryptionMethodsSupported().contains(jweEnc.getName())) {
+        if (!configuration.getProviderMetadata().getIdTokenEncryptionEncValuesSupported().contains(jweEnc.getName())) {
             throw new IllegalStateException("Unsupported ID tokens encryption method :" + jweEnc.getName());
         }
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/ProviderMetadataContoller.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ProviderMetadataContoller.java
@@ -59,7 +59,7 @@ import javax.ws.rs.core.Response.Status;
 @ApplicationScoped
 public class ProviderMetadataContoller {
 
-    private static final String WELL_KNOWN_PREFIX = "/.well-known/openid-configuration";
+    private static final String WELL_KNOWN_CONFIGURATION_ADDRESS = "/.well-known/openid-configuration";
 
     private final Map<String, JsonObject> providerDocuments = new HashMap<>();
 
@@ -78,7 +78,7 @@ public class ProviderMetadataContoller {
     public JsonObject getDocument(String providerURI) {
         if (!providerDocuments.containsKey(providerURI)) {
             JsonObject responseObject;
-            if ("".equals(providerURI)) {
+            if (providerURI.isEmpty()) {
                 // no providerURI provided, data must be load from @OpenIdProviderMetadata
                 responseObject = JsonObject.EMPTY_JSON_OBJECT;
             } else {
@@ -94,8 +94,8 @@ public class ProviderMetadataContoller {
             providerURI = providerURI.substring(0, providerURI.length() - 1);
         }
 
-        if (!providerURI.endsWith(WELL_KNOWN_PREFIX)) {
-            providerURI = providerURI + WELL_KNOWN_PREFIX;
+        if (!providerURI.endsWith(WELL_KNOWN_CONFIGURATION_ADDRESS)) {
+            providerURI = providerURI + WELL_KNOWN_CONFIGURATION_ADDRESS;
         }
 
         Client client = ClientBuilder.newClient();
@@ -113,7 +113,7 @@ public class ProviderMetadataContoller {
             }
         } else {
             throw new IllegalStateException(String.format(
-                    "Unable to retrieve OpenID Provider's [%s] configuration document, HTTP respons code : [%s] ",
+                    "Unable to retrieve OpenID Provider's [%s] configuration document, HTTP response code : [%s] ",
                     providerURI,
                     response.getStatus()
             ));

--- a/openid/src/main/java/fish/payara/security/openid/controller/ProviderMetadataContoller.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ProviderMetadataContoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
@@ -54,7 +54,6 @@ import fish.payara.security.openid.api.OpenIdConstant;
 import fish.payara.security.openid.controller.JWTValidator;
 
 import java.util.Date;
-import java.util.Optional;
 
 import static java.util.Objects.nonNull;
 
@@ -88,7 +87,7 @@ public class AccessTokenImpl implements AccessToken {
         try {
             this.tokenJWT = JWTParser.parse(token);
             jwtClaimsSet = tokenJWT.getJWTClaimsSet();
-            this.claims = jwtClaimsSet.getClaims();
+            this.claims = jwtClaimsSet == null ? null : jwtClaimsSet.getClaims();
         } catch (ParseException ex) {
             // Access token doesn't need to be JWT at all
         }

--- a/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/AccessTokenImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -224,14 +224,18 @@ public class OpenIdContextImpl implements OpenIdContext {
         if (logout == null) {
             LOGGER.log(WARNING, "Logout invoked on session without OpenID session");
             redirect(response, request.getContextPath());
+            return;
         }
-        /**
+        /*
          * See section 5. RP-Initiated Logout
          * https://openid.net/specs/openid-connect-session-1_0.html#RPLogout
          */
+
+        String endSessionEndpoint = configuration.getProviderMetadata().getEndSessionEndpoint();
         if (logout.isNotifyProvider()
-                && !OpenIdUtil.isEmpty(configuration.getProviderMetadata().getEndSessionEndpoint())) {
-            UriBuilder logoutURI = UriBuilder.fromUri(configuration.getProviderMetadata().getEndSessionEndpoint())
+                && !OpenIdUtil.isEmpty(endSessionEndpoint)
+                && getIdentityToken() != null) {
+            UriBuilder logoutURI = UriBuilder.fromUri(endSessionEndpoint)
                     .queryParam(OpenIdConstant.ID_TOKEN_HINT, getIdentityToken().getToken());
             if (!OpenIdUtil.isEmpty(logout.getRedirectURI())) {
                 // User Agent redirected to POST_LOGOUT_REDIRECT_URI after a logout operation performed in OP.

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
@@ -77,6 +77,17 @@ public class OpenIdProviderMetadata {
     private final Set<String> idTokenEncryptionMethodsSupported;
     private final Set<String> subjectTypesSupported;
 
+    public OpenIdProviderMetadata(String issuerURI, Set<String> scopesSupported, Set<String> claimsSupported, Set<String> responseTypeSupported, Set<String> idTokenSigningAlgorithmsSupported, Set<String> idTokenEncryptionAlgorithmsSupported, Set<String> idTokenEncryptionMethodsSupported, Set<String> subjectTypesSupported) {
+        this.issuerURI = issuerURI;
+        this.scopesSupported = scopesSupported;
+        this.claimsSupported = claimsSupported;
+        this.responseTypeSupported = responseTypeSupported;
+        this.idTokenSigningAlgorithmsSupported = idTokenSigningAlgorithmsSupported;
+        this.idTokenEncryptionAlgorithmsSupported = idTokenEncryptionAlgorithmsSupported;
+        this.idTokenEncryptionMethodsSupported = idTokenEncryptionMethodsSupported;
+        this.subjectTypesSupported = subjectTypesSupported;
+    }
+
     public OpenIdProviderMetadata(JsonObject document) {
         this.document = document;
         this.issuerURI = document.getString(ISSUER);

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
@@ -37,26 +37,12 @@
  */
 package fish.payara.security.openid.domain;
 
-import static fish.payara.security.openid.api.OpenIdConstant.CLAIMS_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.ID_TOKEN_ENCRYPTION_ALG_VALUES_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.ID_TOKEN_ENCRYPTION_ENC_VALUES_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.ISSUER;
-import static fish.payara.security.openid.api.OpenIdConstant.RESPONSE_TYPES_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.SCOPES_SUPPORTED;
-import static fish.payara.security.openid.api.OpenIdConstant.SUBJECT_TYPES_SUPPORTED;
 import java.net.URL;
-import static java.util.Collections.emptySet;
-import static java.util.Objects.isNull;
 import java.util.Set;
-import static java.util.stream.Collectors.toSet;
-import javax.json.JsonArray;
 import javax.json.JsonObject;
-import javax.json.JsonString;
-import static javax.json.JsonValue.ValueType.STRING;
 
 /**
- * OpenId Connect provider information
+ * OpenId Connect provider information.
  *
  * @author Gaurav Gupta
  */
@@ -71,33 +57,22 @@ public class OpenIdProviderMetadata {
     private URL jwksURL;
     private final Set<String> scopesSupported;
     private final Set<String> claimsSupported;
-    private final Set<String> responseTypeSupported;
-    private final Set<String> idTokenSigningAlgorithmsSupported;
-    private final Set<String> idTokenEncryptionAlgorithmsSupported;
-    private final Set<String> idTokenEncryptionMethodsSupported;
+    private final Set<String> responseTypesSupported;
+    private final Set<String> idTokenSigningAlgValuesSupported;
+    private final Set<String> idTokenEncryptionAlgValuesSupported;
+    private final Set<String> idTokenEncryptionEncValuesSupported;
     private final Set<String> subjectTypesSupported;
 
-    public OpenIdProviderMetadata(String issuerURI, Set<String> scopesSupported, Set<String> claimsSupported, Set<String> responseTypeSupported, Set<String> idTokenSigningAlgorithmsSupported, Set<String> idTokenEncryptionAlgorithmsSupported, Set<String> idTokenEncryptionMethodsSupported, Set<String> subjectTypesSupported) {
+    public OpenIdProviderMetadata(JsonObject providerDocument, String issuerURI, Set<String> scopesSupported, Set<String> claimsSupported, Set<String> responseTypesSupported, Set<String> idTokenSigningAlgValuesSupported, Set<String> idTokenEncryptionAlgValuesSupported, Set<String> idTokenEncryptionEncValuesSupported, Set<String> subjectTypesSupported) {
+        this.document = providerDocument;
         this.issuerURI = issuerURI;
         this.scopesSupported = scopesSupported;
         this.claimsSupported = claimsSupported;
-        this.responseTypeSupported = responseTypeSupported;
-        this.idTokenSigningAlgorithmsSupported = idTokenSigningAlgorithmsSupported;
-        this.idTokenEncryptionAlgorithmsSupported = idTokenEncryptionAlgorithmsSupported;
-        this.idTokenEncryptionMethodsSupported = idTokenEncryptionMethodsSupported;
+        this.responseTypesSupported = responseTypesSupported;
+        this.idTokenSigningAlgValuesSupported = idTokenSigningAlgValuesSupported;
+        this.idTokenEncryptionAlgValuesSupported = idTokenEncryptionAlgValuesSupported;
+        this.idTokenEncryptionEncValuesSupported = idTokenEncryptionEncValuesSupported;
         this.subjectTypesSupported = subjectTypesSupported;
-    }
-
-    public OpenIdProviderMetadata(JsonObject document) {
-        this.document = document;
-        this.issuerURI = document.getString(ISSUER);
-        this.scopesSupported = getValues(SCOPES_SUPPORTED);
-        this.claimsSupported = getValues(CLAIMS_SUPPORTED);
-        this.responseTypeSupported = getValues(RESPONSE_TYPES_SUPPORTED);
-        this.idTokenSigningAlgorithmsSupported = getValues(ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED);
-        this.idTokenEncryptionAlgorithmsSupported = getValues(ID_TOKEN_ENCRYPTION_ALG_VALUES_SUPPORTED);
-        this.idTokenEncryptionMethodsSupported = getValues(ID_TOKEN_ENCRYPTION_ENC_VALUES_SUPPORTED);
-        this.subjectTypesSupported = getValues(SUBJECT_TYPES_SUPPORTED);
     }
 
     public String getIssuerURI() {
@@ -166,38 +141,24 @@ public class OpenIdProviderMetadata {
         return claimsSupported;
     }
 
-    public Set<String> getResponseTypeSupported() {
-        return responseTypeSupported;
+    public Set<String> getResponseTypesSupported() {
+        return responseTypesSupported;
     }
 
     public Set<String> getSubjectTypesSupported() {
         return subjectTypesSupported;
     }
 
-    public Set<String> getIdTokenSigningAlgorithmsSupported() {
-        return idTokenSigningAlgorithmsSupported;
+    public Set<String> getIdTokenSigningAlgValuesSupported() {
+        return idTokenSigningAlgValuesSupported;
     }
 
-    public Set<String> getIdTokenEncryptionAlgorithmsSupported() {
-        return idTokenEncryptionAlgorithmsSupported;
+    public Set<String> getIdTokenEncryptionAlgValuesSupported() {
+        return idTokenEncryptionAlgValuesSupported;
     }
 
-    public Set<String> getIdTokenEncryptionMethodsSupported() {
-        return idTokenEncryptionMethodsSupported;
-    }
-
-    private Set<String> getValues(String key) {
-        JsonArray jsonArray = document.getJsonArray(key);
-        if (isNull(jsonArray)) {
-            return emptySet();
-        } else {
-            return jsonArray
-                    .stream()
-                    .filter(element -> element.getValueType() == STRING)
-                    .map(element -> (JsonString) element)
-                    .map(JsonString::getString)
-                    .collect(toSet());
-        }
+    public Set<String> getIdTokenEncryptionEncValuesSupported() {
+        return idTokenEncryptionEncValuesSupported;
     }
 
     @Override

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -41,13 +41,27 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * {@link OpenIdProviderMetadata} annotation overrides the openid connect
- * provider's endpoint value, discovered using providerUri.
+ * {@link OpenIdProviderMetadata} annotation overrides the openid connect provider's endpoint value, discovered using
+ * providerUri.
+ *
+ * The documentation: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
  *
  * @author Gaurav Gupta
+ * @author Petr Aubrecht
  */
 @Retention(RUNTIME)
 public @interface OpenIdProviderMetadata {
+
+    /**
+     * Required, FIXME: keep optional for backward compatibility. The base address of OpenId Connect Provider.
+     * <p>
+     * URL using the https scheme with no query or fragment component that the OP asserts as its Issuer Identifier.
+     * </p>
+     * To set this using Microprofile Config use {@code payara.security.openid.provider.issuer}
+     *
+     * @return
+     */
+    String issuer() default "";
 
     /**
      * Required. The URL for the OAuth2 provider to provide authentication
@@ -110,9 +124,96 @@ public @interface OpenIdProviderMetadata {
      */
     String jwksURI() default "";
 
+    //NOT USED: registration_endpoint
+    //RECOMMENDED. URL of the OP's Dynamic Client Registration Endpoint.
+    //
     /**
-     * The Microprofile Config key for the auth endpoint is
-     * <code>{@value}</code>
+     * Recommended. JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this server supports.
+     *
+     * To set this using Microprofile Config use {@code payara.security.openid.provider.scopesSupported}
+     *
+     * @return
+     */
+    String[] scopesSupported() default {};//{"openid"};
+
+    /**
+     * Required. JSON array containing a list of the OAuth 2.0 response_type values that this OP supports.
+     *
+     * To set this using Microprofile Config use {@code payara.security.openid.provider.responseTypeSupported}
+     *
+     * @return
+     */
+    String[] responseTypesSupported() default {};//{"code", "id_token", "token id_token"};
+
+    // NOT USED
+    // response_modes_supported
+    //    OPTIONAL. JSON array containing a list of the OAuth 2.0 response_mode values that this OP supports, as specified in OAuth 2.0 Multiple Response Type Encoding Practices [OAuth.Responses]. If omitted, the default for Dynamic OpenID Providers is ["query", "fragment"].
+    // grant_types_supported
+    //    OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Type values that this OP supports. Dynamic OpenID Providers MUST support the authorization_code and implicit Grant Type values and MAY support other Grant Types. If omitted, the default value is ["authorization_code", "implicit"].
+    // acr_values_supported
+    //    OPTIONAL. JSON array containing a list of the Authentication Context Class References that this OP supports.
+    //
+    /**
+     * Required. JSON array containing a list of the Subject Identifier types that this OP supports. Valid types include
+     * pairwise and public.
+     *
+     * To set this using Microprofile Config use {@code payara.security.openid.provider.subjectTypesSupported}
+     *
+     * @return
+     */
+    String[] subjectTypesSupported() default {};//{"public"};
+
+    /**
+     * Required. REQUIRED. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP
+     * for the ID Token to encode the Claims in a JWT.
+     *
+     * To set this using Microprofile Config use
+     * {@code payara.security.openid.provider.idTokenSigningAlgorithmsSupported}
+     *
+     * @return
+     */
+    String[] idTokenSigningAlgValuesSupported() default {};//{"RS256"};
+
+    /**
+     * Optional. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for the
+     * ID Token to encode the Claims in a JWT.
+     *
+     * To set this using Microprofile Config use
+     * {@code payara.security.openid.provider.idTokenEncryptionAlgValuesSupported}
+     *
+     * @return
+     */
+    String[] idTokenEncryptionAlgValuesSupported() default {};
+
+    /**
+     * Optional. JSON array containing a list of the JWE encryption algorithms (enc values) supported by the OP for the
+     * ID Token to encode the Claims in a JWT.
+     *
+     * To set this using Microprofile Config use
+     * {@code payara.security.openid.provider.idTokenEncryptionEncValuesSupported}
+     *
+     * @return
+     */
+    String[] idTokenEncryptionEncValuesSupported() default {};
+
+    /**
+     * Recommended. JSON array containing a list of the Claim Names of the Claims that the OpenID Provider MAY be able
+     * to supply values for. Note that for privacy or other reasons, this might not be an exhaustive list.
+     *
+     * To set this using Microprofile Config use
+     * {@code payara.security.openid.provider.claimsSupported}
+     *
+     * @return
+     */
+    String[] claimsSupported() default {};
+
+    /**
+     * The Microprofile Config key for the issuer url is <code>{@value}</code>.
+     */
+    String OPENID_MP_ISSUER = "payara.security.openid.provider.issuer";
+
+    /**
+     * The Microprofile Config key for the auth endpoint is <code>{@value}</code>
      */
     String OPENID_MP_AUTHORIZATION_ENDPOINT = "payara.security.openid.provider.authorizationEndpoint";
 
@@ -129,8 +230,7 @@ public @interface OpenIdProviderMetadata {
     String OPENID_MP_USERINFO_ENDPOINT = "payara.security.openid.provider.userinfoEndpoint";
 
    /**
-     * The Microprofile Config key for the end session Endpoint is
-     * <code>{@value}</code>
+     * The Microprofile Config key for the end session Endpoint is     * <code>{@value}</code>
      */
     public static final String OPENID_MP_END_SESSION_ENDPOINT = "payara.security.openid.provider.endSessionEndpoint";
 
@@ -138,5 +238,39 @@ public @interface OpenIdProviderMetadata {
      * The Microprofile Config key for the jwks uri is <code>{@value}</code>
      */
     String OPENID_MP_JWKS_URI = "payara.security.openid.provider.jwksURI";
+
+    /**
+     * The Microprofile Config key for the scopes supported is <code>{@value}</code>
+     */
+    String OPENID_MP_SCOPES_SUPPORTED = "payara.security.openid.provider.scopesSupported";
+
+    /**
+     * The Microprofile Config key for the response types supported is <code>{@value}</code>
+     */
+    String OPENID_MP_RESPONSE_TYPES_SUPPORTED = "payara.security.openid.provider.responseTypesSupported";
+
+    /**
+     * The Microprofile Config key for the subjects types supported is <code>{@value}</code>
+     */
+    String OPENID_MP_SUBJECT_TYPES_SUPPORTED = "payara.security.openid.provider.subjectTypesSupported";
+
+    /**
+     * The Microprofile Config key for the signing algorithms supported is <code>{@value}</code>
+     */
+    String OPENID_MP_ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED = "payara.security.openid.provider.idTokenSigningAlgValuesSupported";
+    /**
+     * The Microprofile Config key for the encryption algorighm alg - values supported is <code>{@value}</code>
+     */
+    String OPENID_MP_ID_TOKEN_ENCRYPTION_ALG_VALUES_SUPPORTED = "payara.security.openid.provider.idTokenEncryptionAlgValuesSupported";
+
+    /**
+     * The Microprofile Config key for the encryption algorighm enc - values supported is <code>{@value}</code>
+     */
+    String OPENID_MP_ID_TOKEN_ENCRYPTION_ENC_VALUES_SUPPORTED = "payara.security.openid.provider.idTokenEncryptionEncValuesSupported";
+
+    /**
+     * The Microprofile Config key for the supported claims supported is <code>{@value}</code>
+     */
+    String OPENID_MP_CLAIMS_SUPPORTED = "payara.security.openid.provider.claimsSupported";
 
 }

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
@@ -53,7 +53,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface OpenIdProviderMetadata {
 
     /**
-     * Required, FIXME: keep optional for backward compatibility. The base address of OpenId Connect Provider.
+     * Required: The base address of OpenId Connect Provider.
      * <p>
      * URL using the https scheme with no query or fragment component that the OP asserts as its Issuer Identifier.
      * </p>
@@ -64,7 +64,7 @@ public @interface OpenIdProviderMetadata {
     String issuer() default "";
 
     /**
-     * Required. The URL for the OAuth2 provider to provide authentication
+     * Required: The URL for the OAuth2 provider to provide authentication.
      * <p>
      * This must be a https endpoint.
      * </p>
@@ -76,7 +76,7 @@ public @interface OpenIdProviderMetadata {
     String authorizationEndpoint() default "";
 
     /**
-     * Required. The URL for the OAuth2 provider to give the authorization token
+     * Required: The URL for the OAuth2 provider to give the authorization token.
      * <p>
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.tokenEndpoint}
@@ -87,8 +87,7 @@ public @interface OpenIdProviderMetadata {
     String tokenEndpoint() default "";
 
     /**
-     * Required. An OAuth 2.0 Protected Resource that returns Claims about the
-     * authenticated End-User.
+     * Required: An OAuth 2.0 Protected Resource that returns Claims about the     * authenticated End-User.
      * <p>
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.userinfoEndpoint}
@@ -99,8 +98,7 @@ public @interface OpenIdProviderMetadata {
     String userinfoEndpoint() default "";
 
     /**
-     * Optional. OP endpoint to notify that the End-User has logged out of the
-     * site and might want to log out of the OP as well.
+     * Optional: OP endpoint to notify that the End-User has logged out of the     * site and might want to log out of the OP as well.
      * <p>
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.endSessionEndpoint}
@@ -111,7 +109,7 @@ public @interface OpenIdProviderMetadata {
     String endSessionEndpoint() default "";
 
     /**
-     * Required. An OpenId Connect Provider's JSON Web Key Set document
+     * Required: An OpenId Connect Provider's JSON Web Key Set document.
      * <p>
      * This contains the signing key(s) the RP uses to validate signatures from
      * the OP. The JWK Set may also contain the Server's encryption key(s),
@@ -128,7 +126,7 @@ public @interface OpenIdProviderMetadata {
     //RECOMMENDED. URL of the OP's Dynamic Client Registration Endpoint.
     //
     /**
-     * Recommended. JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this server supports.
+     * Recommended: List of the OAuth 2.0 scope values that this server supports.
      *
      * To set this using Microprofile Config use {@code payara.security.openid.provider.scopesSupported}
      *
@@ -137,7 +135,7 @@ public @interface OpenIdProviderMetadata {
     String[] scopesSupported() default {};//{"openid"};
 
     /**
-     * Required. JSON array containing a list of the OAuth 2.0 response_type values that this OP supports.
+     * Required: List of the OAuth 2.0 response_type values that this OP supports.
      *
      * To set this using Microprofile Config use {@code payara.security.openid.provider.responseTypeSupported}
      *
@@ -147,15 +145,18 @@ public @interface OpenIdProviderMetadata {
 
     // NOT USED
     // response_modes_supported
-    //    OPTIONAL. JSON array containing a list of the OAuth 2.0 response_mode values that this OP supports, as specified in OAuth 2.0 Multiple Response Type Encoding Practices [OAuth.Responses]. If omitted, the default for Dynamic OpenID Providers is ["query", "fragment"].
+    //    OPTIONAL. List of the OAuth 2.0 response_mode values that this OP supports, as
+    // specified in OAuth 2.0 Multiple Response Type Encoding Practices [OAuth.Responses]. If omitted, the default for
+    // Dynamic OpenID Providers is ["query", "fragment"].
     // grant_types_supported
-    //    OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Type values that this OP supports. Dynamic OpenID Providers MUST support the authorization_code and implicit Grant Type values and MAY support other Grant Types. If omitted, the default value is ["authorization_code", "implicit"].
+    //    OPTIONAL. List of the OAuth 2.0 Grant Type values that this OP supports. Dynamic
+    // OpenID Providers MUST support the authorization_code and implicit Grant Type values and MAY support other Grant
+    // Types. If omitted, the default value is ["authorization_code", "implicit"].
     // acr_values_supported
-    //    OPTIONAL. JSON array containing a list of the Authentication Context Class References that this OP supports.
+    //    OPTIONAL. List of the Authentication Context Class References that this OP supports.
     //
     /**
-     * Required. JSON array containing a list of the Subject Identifier types that this OP supports. Valid types include
-     * pairwise and public.
+     * Required: List of the Subject Identifier types that this OP supports. Valid types include pairwise and public.
      *
      * To set this using Microprofile Config use {@code payara.security.openid.provider.subjectTypesSupported}
      *
@@ -164,8 +165,8 @@ public @interface OpenIdProviderMetadata {
     String[] subjectTypesSupported() default {};//{"public"};
 
     /**
-     * Required. REQUIRED. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP
-     * for the ID Token to encode the Claims in a JWT.
+     * Required: List of the JWS signing algorithms (alg values) supported by the OP for the ID Token to encode the
+     * Claims in a JWT.
      *
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.idTokenSigningAlgorithmsSupported}
@@ -175,8 +176,8 @@ public @interface OpenIdProviderMetadata {
     String[] idTokenSigningAlgValuesSupported() default {};//{"RS256"};
 
     /**
-     * Optional. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for the
-     * ID Token to encode the Claims in a JWT.
+     * Optional: List of the JWE encryption algorithms (alg values) supported by the OP for the ID Token to encode the
+     * Claims in a JWT.
      *
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.idTokenEncryptionAlgValuesSupported}
@@ -186,8 +187,8 @@ public @interface OpenIdProviderMetadata {
     String[] idTokenEncryptionAlgValuesSupported() default {};
 
     /**
-     * Optional. JSON array containing a list of the JWE encryption algorithms (enc values) supported by the OP for the
-     * ID Token to encode the Claims in a JWT.
+     * Optional: List of the JWE encryption algorithms (enc values) supported by the OP for the ID Token to encode the
+     * Claims in a JWT.
      *
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.idTokenEncryptionEncValuesSupported}
@@ -197,8 +198,8 @@ public @interface OpenIdProviderMetadata {
     String[] idTokenEncryptionEncValuesSupported() default {};
 
     /**
-     * Recommended. JSON array containing a list of the Claim Names of the Claims that the OpenID Provider MAY be able
-     * to supply values for. Note that for privacy or other reasons, this might not be an exhaustive list.
+     * Recommended: List of the Claim Names of the Claims that the OpenID Provider MAY be able to supply values for.
+     * Note that for privacy or other reasons, this might not be an exhaustive list.
      *
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.claimsSupported}


### PR DESCRIPTION
# Description

Enhance @OpenIdProviderMetadata with all necessary metadata to skip autoconfiguration as is currently supported by providerURI.

Reproducer is attached to the Jira issue FISH-5741.

Basically, the configuration can provide information this way:

```
@OpenIdAuthenticationDefinition(
        //providerURI = "https://dev-ma-mtmzf.us.auth0.com",
        providerMetadata = @OpenIdProviderMetadata(
                        issuer = "https://dev-ma-mtmzf.us.auth0.com/",
                        authorizationEndpoint = "https://dev-ma-mtmzf.us.auth0.com/authorize",
                        tokenEndpoint = "https://dev-ma-mtmzf.us.auth0.com/oauth/token",
                        userinfoEndpoint = "https://dev-ma-mtmzf.us.auth0.com/userinfo",
                        jwksURI = "https://dev-ma-mtmzf.us.auth0.com/.well-known/jwks.json",
                        responseTypesSupported = {"code", "token", "id_token", "code token", "code id_token",
                            "token id_token", "code token id_token"},
                        subjectTypesSupported = {"public"},
                        idTokenSigningAlgValuesSupported = {"HS256", "RS256"}
                ),
        clientId = "...",
...
```

# How to test
In Payara, pom.xml update security connectors to snapshot:
`<payara.security-connectors.version>2.2.0-SNAPSHOT</payara.security-connectors.version>`

Deploy sample app, login.
Try to comment providerURI, providerMetadata and payara.security.openid.provider.issuer in microprofile-config.properties. This fails with exception complaining issuer is required.
Try to uncomment each option, any of the will work.