### PR TITLE
FISH-5725: unit test for new addition to skip userinfo endpoint

### DIFF
--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -99,6 +99,12 @@
             <artifactId>javax.security.enterprise</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <scope>provided</scope>
@@ -106,6 +112,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -181,7 +181,7 @@ public class OpenIdContextImpl implements OpenIdContext {
      * Method to get user information from Id Token
      * @return JsonObject with user information
      */
-    private JsonObject processUserClaimsFromIDToken() {
+    protected JsonObject processUserClaimsFromIDToken() {
         JwtClaims identityTokenJWTClaims = identityToken.getJwtClaims();
         JwtClaims accessTokenJWTClaims = accessToken.getJwtClaims();
         //setting profile claims from id token

--- a/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
@@ -101,8 +101,9 @@ public class OpenIdContextImplTest {
                 .when(openIdContext).processUserClaimsFromIDToken();
         try {
             claims = openIdContext.getClaimsJson();
+            Assertions.fail("this is not expected to be executed");
         } catch (IllegalStateException e) {
-            Assertions.assertNull(claims);
+            //UserInfo Response is invalid as sub claim must match with the sub Claim in the ID Token
         }
         verify(configuration, times(1)).isUserClaimsFromIDToken();
         verify(openIdContext, times(1)).processUserClaimsFromIDToken();

--- a/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
@@ -41,6 +41,7 @@ package fish.payara.security.openid.domain;
 
 import fish.payara.security.openid.api.AccessToken;
 import fish.payara.security.openid.api.OpenIdConstant;
+import fish.payara.security.openid.controller.UserInfoController;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +67,9 @@ public class OpenIdContextImplTest {
     @Mock
     private AccessToken accessToken;
 
+    @Mock
+    private UserInfoController userInfoController;
+
     @Spy
     @InjectMocks
     private OpenIdContextImpl openIdContext;
@@ -86,6 +90,7 @@ public class OpenIdContextImplTest {
         Assertions.assertNotNull(claims);
         verify(configuration, times(1)).isUserClaimsFromIDToken();
         verify(openIdContext, times(1)).processUserClaimsFromIDToken();
+        verify(userInfoController, times(0)).getUserInfo(configuration, accessToken);
     }
 
     @Test
@@ -101,6 +106,7 @@ public class OpenIdContextImplTest {
         }
         verify(configuration, times(1)).isUserClaimsFromIDToken();
         verify(openIdContext, times(1)).processUserClaimsFromIDToken();
+        verify(userInfoController, times(0)).getUserInfo(configuration, accessToken);
     }
 
 }

--- a/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.security.openid.domain;
+
+import fish.payara.security.openid.api.AccessToken;
+import fish.payara.security.openid.api.OpenIdConstant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@RunWith(JUnitPlatform.class)
+public class OpenIdContextImplTest {
+
+    @Mock
+    private OpenIdConfiguration configuration;
+
+    @Mock
+    private AccessToken accessToken;
+
+    @Spy
+    @InjectMocks
+    private OpenIdContextImpl openIdContext;
+
+    @Test
+    public void skipUserInfoEndpointTest() {
+        JsonObject userInfo = Json.createObjectBuilder()
+                .add(OpenIdConstant.SUBJECT_IDENTIFIER, "LXx-wZ96RrwuRaJs2qcenyHj_FgYSujqLikXMbEvQYE")
+                .add(OpenIdConstant.NAME, "Jason Smith")
+                .add(OpenIdConstant.FAMILY_NAME, "Smith")
+                .add(OpenIdConstant.GIVEN_NAME, "Jason")
+                .add(OpenIdConstant.EMAIL, "jason.smith@payara.fish").build();
+        when(configuration.isUserClaimsFromIDToken()).thenReturn(true);
+        doReturn(userInfo).when(openIdContext).processUserClaimsFromIDToken();
+
+        JsonObject claims = openIdContext.getClaimsJson();
+
+        Assertions.assertNotNull(claims);
+        verify(configuration, times(1)).isUserClaimsFromIDToken();
+        verify(openIdContext, times(1)).processUserClaimsFromIDToken();
+    }
+
+    @Test
+    public void skipUserInfoEndpointThrowsExceptionTest() {
+        JsonObject claims = null;
+        when(configuration.isUserClaimsFromIDToken()).thenReturn(true);
+        doThrow(new IllegalStateException("UserInfo Response is invalid"))
+                .when(openIdContext).processUserClaimsFromIDToken();
+        try {
+            claims = openIdContext.getClaimsJson();
+        } catch(IllegalStateException e) {
+            Assertions.assertNull(claims);
+        }
+        verify(configuration, times(1)).isUserClaimsFromIDToken();
+        verify(openIdContext, times(1)).processUserClaimsFromIDToken();
+    }
+
+}

--- a/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/OpenIdContextImplTest.java
@@ -96,7 +96,7 @@ public class OpenIdContextImplTest {
                 .when(openIdContext).processUserClaimsFromIDToken();
         try {
             claims = openIdContext.getClaimsJson();
-        } catch(IllegalStateException e) {
+        } catch (IllegalStateException e) {
             Assertions.assertNull(claims);
         }
         verify(configuration, times(1)).isUserClaimsFromIDToken();


### PR DESCRIPTION
this is the unit test related to the last changes to skip the userinfo endpoint with the new property userClaimsFromIDToken