### PR TITLE
Fish 5742 subject type supported metadata

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -318,9 +318,6 @@ public class ConfigurationController implements Serializable {
         if (configuration.getProviderMetadata().getResponseTypesSupported().isEmpty()) {
             errorMessages.add("response_types_supported metadata is mandatory");
         }
-        if (configuration.getProviderMetadata().getResponseTypesSupported().isEmpty()) {
-            errorMessages.add("subject_types_supported metadata is mandatory");
-        }
         if (configuration.getProviderMetadata().getIdTokenSigningAlgValuesSupported().isEmpty()) {
             errorMessages.add("id_token_signing_alg_values_supported metadata is mandatory");
         }

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
@@ -156,7 +156,8 @@ public @interface OpenIdProviderMetadata {
     //    OPTIONAL. List of the Authentication Context Class References that this OP supports.
     //
     /**
-     * Required: List of the Subject Identifier types that this OP supports. Valid types include pairwise and public.
+     * Required by standard, but not used by Payara for now: List of the Subject Identifier types that this OP supports.
+     * Valid types include pairwise and public.
      *
      * To set this using Microprofile Config use {@code payara.security.openid.provider.subjectTypesSupported}
      *


### PR DESCRIPTION
Payara currently doesn't use subjectTypesSupported in OpenIdProviderMetadata plus there was its broken validation. This PR removes the validation completely and adds a comment, that the attribute is not used by the connector.