### PR TITLE
Fish-386:relaxing validation for scopes security connector

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -217,7 +217,7 @@ public class ConfigurationController implements Serializable {
         boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
         String extraParamsRaw = OpenIdUtil.getConfiguredValue(String.class, extraParametersFromAnnotation, provider, OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW);
         Map<String, List<String>> extraParameters = parseMultiMapFromUrlQuery(extraParamsRaw);
-        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, null, provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
+        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, false, provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
 
         fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
                 providerDocument,

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -72,6 +72,7 @@ public class OpenIdConfiguration {
     private int tokenMinValidity;
     private JWTValidator validator;
     private boolean userClaimsFromIDToken;
+    private boolean disableScopeValidation;
 
     static final String BASE_URL_EXPRESSION = "${baseURL}";
 
@@ -264,6 +265,15 @@ public class OpenIdConfiguration {
         return this;
     }
 
+    public boolean isDisableScopeValidation() {
+        return disableScopeValidation;
+    }
+
+    public OpenIdConfiguration setDisableScopeValidation(boolean disableScopeValidation) {
+        this.disableScopeValidation = disableScopeValidation;
+        return this;
+    }
+
     @Override
     public String toString() {
         return OpenIdConfiguration.class.getSimpleName()
@@ -285,6 +295,7 @@ public class OpenIdConfiguration {
                 + ", tokenAutoRefresh=" + tokenAutoRefresh
                 + ", tokenMinValidity=" + tokenMinValidity
                 + ", userClaimsFromIDToken=" + userClaimsFromIDToken
+                + ", disableScopeValidation=" + disableScopeValidation
                 + '}';
     }
 

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -381,4 +381,9 @@ public @interface OpenIdAuthenticationDefinition {
      * pairs: {@code key=value&key2=value+with+spaces}. The keys may repeat.
      */
     String OPENID_MP_EXTRA_PARAMS_RAW = "payara.security.openid.extraParams.raw";
+
+    /**
+     * The Microprofile Config key to disable scope validation is <code>{@value}</code>
+     */
+    String OPENID_MP_DISABLE_SCOPE_VALIDATION = "payara.security.openid.disableScopeValidation";
 }


### PR DESCRIPTION
Adding new MP config property to relax scope validation 