### PR TITLE
Fish 383 working oauth for azure ad b2c

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -50,7 +50,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.json.Json;
-import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.security.auth.callback.Callback;
@@ -74,7 +73,6 @@ import fish.payara.security.openid.api.RefreshToken;
 import fish.payara.security.openid.controller.AuthenticationController;
 import fish.payara.security.openid.controller.StateController;
 import fish.payara.security.openid.controller.TokenController;
-import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.LogoutConfiguration;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdContextImpl;
@@ -417,9 +415,9 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
         if (nonNull(refreshToken)) {
             context.setRefreshToken(new RefreshTokenImpl(refreshToken));
         }
-        JsonNumber expiresIn = tokensObject.getJsonNumber(EXPIRES_IN);
+        Long expiresIn = OpenIdUtil.parseLong(tokensObject, EXPIRES_IN);
         if (nonNull(expiresIn)) {
-            context.setExpiresIn(expiresIn.longValue());
+            context.setExpiresIn(expiresIn);
         }
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdCredential.java
@@ -46,7 +46,6 @@ import static fish.payara.security.openid.api.OpenIdConstant.SCOPE;
 import static fish.payara.security.openid.api.OpenIdConstant.TOKEN_TYPE;
 import fish.payara.security.openid.domain.AccessTokenImpl;
 import fish.payara.security.openid.domain.IdentityTokenImpl;
-import fish.payara.security.openid.domain.OpenIdConfiguration;
 
 import static java.util.Objects.nonNull;
 import javax.json.JsonObject;
@@ -72,8 +71,8 @@ public class OpenIdCredential implements Credential {
         this.identityToken = new IdentityTokenImpl(tokensObject.getString(IDENTITY_TOKEN), tokenMinValidity);
         String accessTokenString = tokensObject.getString(ACCESS_TOKEN, null);
         Long expiresIn = null;
-        if(nonNull(tokensObject.getJsonNumber(EXPIRES_IN))){
-            expiresIn = tokensObject.getJsonNumber(EXPIRES_IN).longValue();
+        if (tokensObject.containsKey(EXPIRES_IN)) {
+            expiresIn = OpenIdUtil.parseLong(tokensObject, EXPIRES_IN);
         }
         String tokenType = tokensObject.getString(TOKEN_TYPE, null);
         String scopeString = tokensObject.getString(SCOPE, null);

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -46,8 +46,10 @@ import java.util.function.Predicate;
 import javax.el.ELProcessor;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.json.JsonArray;
+import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonString;
+import javax.json.JsonValue;
 import static javax.json.JsonValue.ValueType.STRING;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -151,5 +153,24 @@ public final class OpenIdUtil {
      */
     public static boolean isEmpty(String value) {
         return value == null || value.trim().length() == 0;
+    }
+
+    /**
+     * Parse a JSON value as long even if it is provided as a string.
+     *
+     * @param json json object
+     * @param fieldName name of the field (key)
+     * @return long representation of the field
+     */
+    public static Long parseLong(JsonObject json, String fieldName) {
+        Long longField = null;
+        JsonValue jsonField = json.get(fieldName);
+        if (jsonField instanceof JsonNumber) {
+            longField = ((JsonNumber) jsonField).longValue();
+        } else if (jsonField instanceof JsonString) {
+            // Microsoft Azure AD B2C returns expires_in value as a string
+            longField = Long.valueOf(((JsonString) jsonField).getString());
+        }
+        return longField;
     }
 }

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -397,10 +397,13 @@ public class ConfigurationController implements Serializable {
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             String[] keyValue = pair.split("=");
-            String key = keyValue[0];
-            String value = keyValue.length > 1 ? URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8) : null;
-            List<String> values = multiMap.computeIfAbsent(key, k -> new ArrayList<>());
-            values.add(value);
+            if (keyValue.length > 0 && keyValue[0].length() > 0) {
+                // process only key-value pairs with key
+                String key = keyValue[0];
+                String value = keyValue.length > 1 ? URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8) : null;
+                List<String> values = multiMap.computeIfAbsent(key, k -> new ArrayList<>());
+                values.add(value);
+            }
         }
         return multiMap;
     }

--- a/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
@@ -105,6 +105,12 @@ public class ConfigurationControllerTest {
     }
 
     @Test
+    public void parseMultiMapFromUrlEmptyString() {
+        Map<String, List<String>> result = new HashMap<>();
+        assertEquals(result, ConfigurationController.parseMultiMapFromUrlQuery(""));
+    }
+
+    @Test
     public void parseMultiMapFromUrlQuery() {
         Map<String, List<String>> result = new HashMap<>();
         result.put("a", Arrays.asList("b"));


### PR DESCRIPTION
Make the @OpenIdAuthenticationDefinition working also for Azure AD B2C, basically make parsing of expires_in more tolerant, expected number but provided a string.
Reproducing application is attached to the Jira ticket.
```
@OpenIdAuthenticationDefinition(
        providerURI = "https://login.microsoftonline.com/${APP_ID}/",
        providerMetadata = @OpenIdProviderMetadata(
                // MS "supports" only openid, others fail validation
                scopesSupported = {"email", "profile", "openid"}
        ),
        clientId = "${CLIENT_ID}",
        clientSecret = "{CLIENT_SECRET}",
        redirectURI = "${baseURL}/callback",
        logout = @LogoutDefinition(notifyProvider = true, redirectURI = "http://localhost:8080/OpenIdReproducer/"),
        // long enough timeouts to be sure
        jwksConnectTimeout = 2_000,
        jwksReadTimeout = 2_000
)
```
Both Login and logout work well.
