### PR TITLE
FISH-386: adding annotation property to relax scope validation

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
@@ -174,6 +174,11 @@ public class AzureDefinitionConverter {
             public boolean userClaimsFromIDToken() {
                 return azureDefinition.userClaimsFromIDToken();
             }
+
+            @Override
+            public boolean disableScopeValidation() {
+                return azureDefinition.providerMetadata().disableScopeValidation();
+            }
         };
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
@@ -162,6 +162,11 @@ public class GoogleDefinitionConverter {
             public boolean userClaimsFromIDToken() {
                 return googleDefinition.userClaimsFromIDToken();
             }
+
+            @Override
+            public boolean disableScopeValidation() {
+                return googleDefinition.providerMetadata().disableScopeValidation();
+            }
         };
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -217,7 +217,7 @@ public class ConfigurationController implements Serializable {
         boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
         String extraParamsRaw = OpenIdUtil.getConfiguredValue(String.class, extraParametersFromAnnotation, provider, OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW);
         Map<String, List<String>> extraParameters = parseMultiMapFromUrlQuery(extraParamsRaw);
-        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, false, provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
+        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, providerMetadata.disableScopeValidation(), provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
 
         fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
                 providerDocument,

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -243,6 +243,13 @@ public @interface OpenIdAuthenticationDefinition {
     boolean userClaimsFromIDToken() default false;
 
     /**
+     * Optional: Indicates to disable the scope validation.
+     *
+     * @return
+     */
+    boolean disableScopeValidation() default false;
+
+    /**
      * The Microprofile Config key for the provider uri is <code>{@value}</code>
      */
     String OPENID_MP_PROVIDER_URI = "payara.security.openid.providerURI";

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
@@ -210,6 +210,13 @@ public @interface OpenIdProviderMetadata {
     String[] claimsSupported() default {};
 
     /**
+     * Optional: Indicates to disable the scope validation.
+     *
+     * @return
+     */
+    boolean disableScopeValidation() default false;
+
+    /**
      * The Microprofile Config key for the issuer url is <code>{@value}</code>.
      */
     String OPENID_MP_ISSUER = "payara.security.openid.provider.issuer";


### PR DESCRIPTION
Adding annotation property for OpenIdProviderMetadata to relax scope validation and be more consistent with implementation and complement the MP config that was already merged:

@AzureAuthenticationDefinition(clientId = "c6a4139e-eaac-4402-b72e-f52945882fc1", clientSecret = "WT37Q~xqXly0E69S~6xJm_B.AAbKM0~3SHOqu",
        tenantId = "f1195e3a-584e-4eba-867f-030b6d4cffa9",
        scope={"newScope"}, userClaimsFromIDToken = true, providerMetadata = @OpenIdProviderMetadata(
                disableScopeValidation = true
))


I tested on local environment and both MP Config property and Annotation property work well