### PR TITLE
FISH-5941: Relocate nimbus-jwt classes in openid connector

### DIFF
--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -94,14 +94,6 @@
                             <pattern>fish.payara.security</pattern>
                             <shadedPattern>fish.payara.security.connectors</shadedPattern>
                         </relocation>
-                        <relocation>
-                            <pattern>com</pattern>
-                            <shadedPattern>fish.payara.security.connectors.shaded</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>net</pattern>
-                            <shadedPattern>fish.payara.security.connectors.shaded</shadedPattern>
-                        </relocation>
                     </relocations>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -143,16 +143,71 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>
+                            !fish.payara.security.openid.api,
                             fish.payara.security.openid.*
                         </Export-Package>
                         <!-- Import API classes, other are NimbusDS optional dependencies -->
                         <Import-Package>
                             javax.*, fish.payara.*, 
                             org.eclipse.microprofile.config;version="[1.0,3)", 
-                            org.eclipse.*, *;resolution:=optional
+                            *;resolution:=optional
                         </Import-Package>
+                        <!-- Package NimbusDS with the connector, so that server doesn't need to
+                            distribute it explicitly. We shade it in next step -->
+                        <Embed-Dependency>
+                            nimbus-jose-jwt;inline=true,
+                            jcip-annotations;inline=true
+                        </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <createSourcesJar>true</createSourcesJar>
+                    <artifactSet>
+                        <includes>
+                            <include>com.nimbusds:*</include>
+                            <include>com.github.stephenc.jcip:*</include>
+                        </includes>
+                    </artifactSet>
+                    <filters>
+                        <!-- bundle plugin already inlined the classes, so we can skip the contents -->
+                        <filter>
+                            <artifact>com.nimbusds:*</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>com.github.stephenc.jcip:*</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <relocations>
+                        <relocation>
+                            <pattern>com</pattern>
+                            <shadedPattern>fish.payara.security.shaded</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net</pattern>
+                            <shadedPattern>fish.payara.security.shaded</shadedPattern>
+                        </relocation>
+                    </relocations>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
We don't want to interfere with server's classes and just not exporting them still causes
LinkageErrors when users' applications still use nimbus-jwt.

We let bundle plugin do the inclusion and then shade plugin to make relocation and
source jar