### PR TITLE
redirect and logout URIs should be built using UriBuilder.build()

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdIdentityStore.java
@@ -139,9 +139,9 @@ public class OpenIdIdentityStore implements IdentityStore {
         if (OpenIdConstant.SUBJECT_IDENTIFIER.equals(callerNameClaim)) {
             return context.getSubject();
         }
-        String callerName = (String) context.getIdentityToken().getJwtClaims().getStringClaim(callerNameClaim).orElse(null);
+        String callerName = context.getIdentityToken().getJwtClaims().getStringClaim(callerNameClaim).orElse(null);
         if (callerName == null) {
-            callerName = (String) context.getAccessToken().getJwtClaims().getStringClaim(callerNameClaim).orElse(null);
+            callerName = context.getAccessToken().getJwtClaims().getStringClaim(callerNameClaim).orElse(null);
         }
         if (callerName == null) {
             callerName = context.getClaims().getStringClaim(callerNameClaim).orElse(null);

--- a/openid/src/main/java/fish/payara/security/openid/controller/AuthenticationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/AuthenticationController.java
@@ -127,12 +127,12 @@ public class AuthenticationController {
         }
 
         configuration.getExtraParameters().forEach(
-                (key, values) -> values.stream().forEach(
+                (key, values) -> values.forEach(
                         value -> authRequest.queryParam(key, value)
                 )
         );
 
-        String authUrl = authRequest.toString();
+        String authUrl = authRequest.build().toASCIIString();
         LOGGER.log(FINEST, "Redirecting for authentication to {0}", authUrl);
         try {
             response.sendRedirect(authUrl);

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -241,7 +241,7 @@ public class OpenIdContextImpl implements OpenIdContext {
                 // User Agent redirected to POST_LOGOUT_REDIRECT_URI after a logout operation performed in OP.
                 logoutURI.queryParam(OpenIdConstant.POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
             }
-            redirect(response, logoutURI.toString());
+            redirect(response, logoutURI.build().toASCIIString());
         } else if (!OpenIdUtil.isEmpty(logout.getRedirectURI())) {
             redirect(response, logout.buildRedirectURI(request));
         } else {

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/ClaimsDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/ClaimsDefinition.java
@@ -55,7 +55,7 @@ public @interface ClaimsDefinition {
      * The Microprofile Config key for the callerName claim is
      * <code>{@value}</code>
      */
-    public static final String OPENID_MP_CALLER_NAME_CLAIM = "payara.security.openid.callerNameClaim";
+    String OPENID_MP_CALLER_NAME_CLAIM = "payara.security.openid.callerNameClaim";
 
     /**
      * Maps the callerNameClaim's value to caller name value in
@@ -74,7 +74,7 @@ public @interface ClaimsDefinition {
      * The Microprofile Config key for the callerGroups claim is
      * <code>{@value}</code>
      */
-    public static final String OPENID_MP_CALLER_GROUP_CLAIM = "payara.security.openid.callerGroupsClaim";
+    String OPENID_MP_CALLER_GROUP_CLAIM = "payara.security.openid.callerGroupsClaim";
 
     /**
      * Maps the callerGroupsClaim's value to caller groups value in


### PR DESCRIPTION
I tried to use the openid-standalone module with JBoss but the redirection fails as I keep being redirected to /org.jboss.resteasy.specimpl.ResteasyUriBuilder@XXXX because redirection URIs are built using `UriBuilder.toString()` instead of `UriBuilder.build()`.