### PR TITLE
FISH-6434: Support for access token issuer different from ID token one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ buildNumber.properties
 !/.mvn/wrapper/maven-wrapper.jar
 *.iml
 .idea
+*.orig

--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -89,6 +89,7 @@
         <dependency>
             <groupId>fish.payara.security.connectors</groupId>
             <artifactId>openid-standalone</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  ~
+  ~  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security-connectors-parent</artifactId>
+        <groupId>fish.payara.security.connectors</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>openid-standalone-it</artifactId>
+
+    <properties>
+        <version.payara>5.2022.2</version.payara>
+        <version.arquillian>1.7.0.Alpha12</version.arquillian>
+        <version.junit>5.9.0</version.junit>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${version.payara}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.security.connectors</groupId>
+            <artifactId>openid-standalone</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.23</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <version>3.1.4</version>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>payara-server-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>payara-server-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- download and unpack payara server -->
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                                    <markersDirectory>
+                                        ${session.executionRootDirectory}/target/dependency-maven-plugin-markers
+                                    </markersDirectory>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.distributions</groupId>
+                                            <artifactId>payara</artifactId>
+                                            <type>zip</type>
+                                            <version>${version.payara}</version>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${session.executionRootDirectory}/target</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- pass server location to test -->
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Pass location of server installation to arquillian container -->
+                                <payara.home>${session.executionRootDirectory}/target/payara6</payara.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>payara-micro-managed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-micro-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>fish.payara.extras</groupId>
+                    <artifactId>payara-micro</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>payara-micro-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-micro-remote</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>payara-micro-deployer</artifactId>
+                    <scope>test</scope>
+                    <type>war</type>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deployer-for-tests</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.arquillian</groupId>
+                                            <artifactId>payara-micro-deployer</artifactId>
+                                            <type>war</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <execution>
+                                <id>start-test-instance</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war
+                                            </value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-test-instance</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <payaraVersion>${version.payara}</payaraVersion>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -88,6 +88,12 @@
     <dependencies>
         <dependency>
             <groupId>fish.payara.security.connectors</groupId>
+            <artifactId>security-connectors-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.security.connectors</groupId>
             <artifactId>openid-standalone</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -177,6 +183,12 @@
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-remote</artifactId>
                     <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
@@ -180,9 +180,8 @@ public abstract class AbstractIdProvider {
     @Path("token")
     @POST
     @Consumes(APPLICATION_FORM_URLENCODED)
-    public Response tokenEndpoint(@BeanParam TokenRequest tokenRequest, MultivaluedMap<String, String> allParams) {
-        //TokenRequest tokenRequest = new TokenRequest(allParams);
-        tokenRequest.allParams = allParams;
+    public Response tokenEndpoint(MultivaluedMap<String, String> allParams) {
+        TokenRequest tokenRequest = new TokenRequest(allParams);
 
         try {
             Token result;
@@ -434,6 +433,7 @@ public abstract class AbstractIdProvider {
 
         public TokenRequest(MultivaluedMap<String, String> allParams) {
             this.allParams = allParams;
+            code = allParams.getFirst(CODE);
             clientId = allParams.getFirst(CLIENT_ID);
             clientSecret = allParams.getFirst(CLIENT_SECRET);
             grantType = allParams.getFirst(GRANT_TYPE);

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
@@ -1,0 +1,383 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.openid.idp;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.*;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+/**
+ * @author Gaurav Gupta
+ * @author Patrik Dudits
+ */
+public abstract class AbstractIdProvider {
+
+
+    static final String AUTHORIZATION_HEADER = "Authorization";
+
+    static final String BEARER_TYPE = "Bearer";
+
+    private static final ConcurrentMap<String, AuthCode> codeRepo = new ConcurrentHashMap<>();
+
+    private static final ConcurrentMap<String, Token> tokenRepo = new ConcurrentHashMap<>();
+
+    protected static void clear() {
+        tokenRepo.clear();
+        codeRepo.clear();
+    }
+
+    private final Logger LOGGER = Logger.getLogger(getClass().getName());
+
+    @Path(".well-known/openid-configuration")
+    @GET
+    @Produces
+    public Response getConfiguration(@Context UriInfo uri) {
+
+        URI providerRoot = providerRoot(uri);
+        JsonObjectBuilder baseConfig = Json.createObjectBuilder()
+                .add("issuer", providerRoot.toString())
+                .add("authorization_endpoint", providerRoot.resolve("auth").toString())
+                .add("token_endpoint", providerRoot.resolve("token").toString())
+                .add("userinfo_endpoint", providerRoot.resolve("userinfo").toString())
+                .add("jwks_uri", providerRoot.resolve("jwks").toString())
+                .add("scopes_supported", Json.createArrayBuilder().add("openid").add("email").add("profile"))
+                .add("response_types_supported", Json.createArrayBuilder().add("code").add("id_token").add("token id_token"))
+                .add("subject_types_supported", Json.createArrayBuilder().add("public"))
+                .add("id_token_signing_alg_values_supported", Json.createArrayBuilder().add("RS256").add("none"))
+                .add("claims_supported", Json.createArrayBuilder().add("aud").add("email"));
+
+        customizeConfig(baseConfig, providerRoot);
+        return Response.ok(baseConfig.build())
+                .header("Access-Control-Allow-Origin", "*")
+                .build();
+    }
+
+    protected URI providerRoot(UriInfo uri) {
+        URI providerRoot = uri.getRequestUri().resolve("../");
+        return providerRoot;
+    }
+
+    protected void customizeConfig(JsonObjectBuilder baseConfig, URI providerRoot) {
+
+    }
+
+    @Path("auth")
+    @GET
+    @Produces
+    public Response authEndpoint(@BeanParam AuthRequest authRequest) throws URISyntaxException {
+        try {
+            AuthCode result = new AuthCode(authRequest);
+            result.setIdentity(authenticate(authRequest));
+            codeRepo.put(result.getCode(), result);
+            UriBuilder redirectBuilder = UriBuilder.fromUri(authRequest.redirectUri).queryParam(CODE, result.getCode());
+            if (authRequest.getState() != null) {
+                redirectBuilder.queryParam(STATE, authRequest.getState());
+            }
+            URI returnUrl = redirectBuilder.build();
+            LOGGER.info("Authorization successful, redirecting to " + returnUrl);
+            return Response.seeOther(returnUrl).build();
+        } catch (AuthException ae) {
+            LOGGER.log(INFO, "Authentication failed", ae);
+            return Response.status(Response.Status.BAD_REQUEST).type(APPLICATION_JSON).entity(ae.asJson()).build();
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "Authentication Exception", e);
+            return Response.serverError().type(APPLICATION_JSON).entity(new AuthException("server_error", null, authRequest.getState()).asJson()).build();
+        }
+    }
+
+    /**
+     * Validate authentication request and return any identity data to be used during token exchange.
+     *
+     * @param request
+     * @return
+     * @throws AuthException
+     */
+    protected abstract Object authenticate(AuthRequest request) throws AuthException;
+
+    @Path("token")
+    @POST
+    @Consumes(APPLICATION_FORM_URLENCODED)
+    public Response tokenEndpoint(@BeanParam TokenRequest tokenRequest, MultivaluedMap<String, String> allParams) {
+        //TokenRequest tokenRequest = new TokenRequest(allParams);
+        tokenRequest.allParams = allParams;
+
+        try {
+            Token result;
+            if (AUTHORIZATION_CODE.equals(tokenRequest.grantType)) {
+                AuthCode code = codeRepo.remove(tokenRequest.code);
+                if (code == null) {
+                    throw new AuthException("invalid_code");
+                }
+                result = exchangeToken(code);
+            } else {
+                result = exchangeToken(tokenRequest);
+            }
+            if (result == null) {
+                throw new AuthException("invalid_code", "No token exchanged");
+            }
+            JsonObjectBuilder builder = Json.createObjectBuilder();
+            JWT idToken = encodeJWT(result.getIdToken());
+            String accessToken = result.getAccessToken(this::encodeJWT);
+            builder.add(IDENTITY_TOKEN, idToken.serialize())
+                    .add(ACCESS_TOKEN, accessToken)
+                    .add(TOKEN_TYPE, BEARER_TYPE)
+                    .add(EXPIRES_IN, result.getDurationInSeconds());
+            if (result.getRefreshToken() != null) {
+                builder.add("refresh_token", result.refreshToken);
+            }
+            tokenRepo.put(accessToken, result);
+            return Response.ok().type(APPLICATION_JSON).entity(builder.build()).build();
+        } catch (AuthException ae) {
+            LOGGER.log(INFO, "Token exchange failed", ae);
+            return Response.status(Response.Status.BAD_REQUEST).type(APPLICATION_JSON).entity(ae.asJson()).build();
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "Token exchange Exception", e);
+            return Response.serverError().type(APPLICATION_JSON).entity(new AuthException("server_error").asJson()).build();
+        }
+
+    }
+
+    protected abstract Token exchangeToken(AuthCode code) throws AuthException;
+
+    protected abstract Token exchangeToken(TokenRequest request) throws AuthException;
+
+    protected abstract JWT encodeJWT(JWTClaimsSet claims);
+
+    @Path("userinfo")
+    @Produces(APPLICATION_JSON)
+    @GET
+    public Response userinfoEndpoint(@HeaderParam(AUTHORIZATION_HEADER) String authorizationHeader) {
+        String accessToken = authorizationHeader.substring(BEARER_TYPE.length() + 1);
+        Token token = tokenRepo.get(accessToken);
+
+        try {
+            if (token == null) {
+                throw new AuthException("invalid_token");
+            }
+            // TODO: if access token is JWT, validate JWT
+            JsonObject userInfo = userInfo(token);
+            return Response.ok(userInfo).build();
+        } catch (AuthException ae) {
+            LOGGER.log(INFO, "User info failed", ae);
+            return Response.status(Response.Status.BAD_REQUEST).entity(ae.asJson()).build();
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "User info Exception", e);
+            return Response.serverError().entity(new AuthException("server_error").asJson()).build();
+        }
+    }
+
+    protected abstract JsonObject userInfo(Token token);
+
+    protected static class AuthException extends Exception {
+        private final String errorCode;
+
+        private final String state;
+
+        public AuthException(String errorCode) {
+            this(errorCode, null, null);
+        }
+
+        AuthException(String errorCode, String description, String state) {
+            super(description);
+            this.errorCode = Objects.requireNonNull(errorCode);
+            this.state = state;
+        }
+
+        AuthException(String errorCode, String description) {
+            this(errorCode, description, null);
+        }
+
+        JsonObject asJson() {
+            JsonObjectBuilder builder = Json.createObjectBuilder()
+                    .add("error", errorCode);
+            if (getMessage() != null) {
+                builder.add("error_description", getMessage());
+            }
+            if (state != null) {
+                builder.add("state", state);
+            }
+            return builder.build();
+        }
+    }
+
+    protected static class AuthRequest {
+        @QueryParam(CLIENT_ID)
+        String clientId;
+
+        @QueryParam(SCOPE)
+        String scope;
+
+        @QueryParam(RESPONSE_TYPE)
+        String responseType;
+
+        @QueryParam(NONCE)
+        String nonce;
+
+        @QueryParam(STATE)
+        String state;
+
+        @QueryParam(REDIRECT_URI)
+        String redirectUri;
+
+        @Context
+        UriInfo uriInfo;
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public String getScope() {
+            return scope;
+        }
+
+        public String getResponseType() {
+            return responseType;
+        }
+
+        public String getNonce() {
+            return nonce;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public String getRedirectUri() {
+            return redirectUri;
+        }
+
+        public String getParameter(String parameterName) {
+            return uriInfo.getQueryParameters().getFirst(parameterName);
+        }
+
+        public List<String> getParameterValues(String parameterName) {
+            return uriInfo.getQueryParameters().get(parameterName);
+        }
+
+        public boolean hasParameter(String parameterName) {
+            return uriInfo.getQueryParameters().containsKey(parameterName);
+        }
+
+        public Iterable<String> parameterNames() {
+            return uriInfo.getQueryParameters().keySet();
+        }
+    }
+
+    protected static class TokenRequest {
+        @FormParam(CLIENT_ID)
+        String clientId;
+
+        @FormParam(CLIENT_SECRET)
+        String clientSecret;
+
+        @FormParam(GRANT_TYPE)
+        String grantType;
+
+        @FormParam(CODE)
+        String code;
+
+        @FormParam(REDIRECT_URI)
+        String redirectUri;
+
+
+        private MultivaluedMap<String, String> allParams;
+
+        public TokenRequest() {
+            // for beanparams
+        }
+
+        public TokenRequest(MultivaluedMap<String, String> allParams) {
+            this.allParams = allParams;
+            clientId = allParams.getFirst(CLIENT_ID);
+            clientSecret = allParams.getFirst(CLIENT_SECRET);
+            grantType = allParams.getFirst(GRANT_TYPE);
+            redirectUri = allParams.getFirst(REDIRECT_URI);
+        }
+
+        public String getParameter(String parameterName) {
+            return allParams.getFirst(parameterName);
+        }
+
+        public List<String> getParameterValues(String parameterName) {
+            return allParams.get(parameterName);
+        }
+
+        public boolean hasParameter(String parameterName) {
+            return allParams.containsKey(parameterName);
+        }
+
+        public Iterable<String> parameterNames() {
+            return allParams.keySet();
+        }
+    }
+
+
+}

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AbstractIdProvider.java
@@ -101,6 +101,9 @@ public abstract class AbstractIdProvider {
 
     private static final ConcurrentMap<String, Token> tokenRepo = new ConcurrentHashMap<>();
 
+    @Context
+    protected UriInfo uriInfo;
+
     protected static void clear() {
         tokenRepo.clear();
         codeRepo.clear();
@@ -236,7 +239,9 @@ public abstract class AbstractIdProvider {
 
     protected abstract Token exchangeToken(AuthCode code) throws AuthException;
 
-    protected abstract Token exchangeToken(TokenRequest request) throws AuthException;
+    protected Token exchangeToken(TokenRequest request) throws AuthException {
+        throw new AuthException("not_supported");
+    }
 
     protected abstract JWT encodeJWT(JWTClaimsSet claims) throws JOSEException;
 
@@ -433,6 +438,26 @@ public abstract class AbstractIdProvider {
             clientSecret = allParams.getFirst(CLIENT_SECRET);
             grantType = allParams.getFirst(GRANT_TYPE);
             redirectUri = allParams.getFirst(REDIRECT_URI);
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public String getClientSecret() {
+            return clientSecret;
+        }
+
+        public String getGrantType() {
+            return grantType;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getRedirectUri() {
+            return redirectUri;
         }
 
         public String getParameter(String parameterName) {

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AuthCode.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/AuthCode.java
@@ -1,0 +1,93 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp;
+
+import java.util.Base64;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class AuthCode {
+
+
+    private final String code;
+
+    private final String nonce;
+
+    private final String clientId;
+
+    private final String state;
+
+    private Object identity;
+
+    AuthCode(AbstractIdProvider.AuthRequest request) {
+        byte[] code = new byte[8];
+        ThreadLocalRandom.current().nextBytes(code);
+        this.code = Base64.getEncoder().encodeToString(code);
+        this.nonce = request.nonce;
+        this.clientId = request.clientId;
+        this.state = request.getState();
+    }
+
+    public Object getIdentity() {
+        return identity;
+    }
+
+    void setIdentity(Object identity) {
+        this.identity = identity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/Token.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/Token.java
@@ -1,0 +1,132 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Function;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+public class Token {
+    public String refreshToken;
+
+    private JWTClaimsSet idToken;
+
+    private JWTClaimsSet accessTokenJwt;
+
+    private String accessTokenString;
+
+    private Instant validityStart = Instant.now();
+
+    private Duration duration = Duration.ofMinutes(5);
+
+
+    public JWTClaimsSet getIdToken() {
+        return idToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public Instant getValidityStart() {
+        return validityStart;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public long getDurationInSeconds() {
+        return duration.toMillis() / 1000;
+    }
+
+    public String getAccessToken(Function<JWTClaimsSet, JWT> tokenGenerator) {
+        if (accessTokenJwt != null) {
+            return tokenGenerator.apply(accessTokenJwt).serialize();
+        } else {
+            return accessTokenString;
+        }
+    }
+
+    public JWTClaimsSet.Builder claimsFor(AuthCode code, URI issuer, String subject) {
+        return new JWTClaimsSet.Builder()
+                .audience(code.getClientId())
+                .subject(subject)
+                .expirationTime(new Date(validityStart.plus(duration).toEpochMilli()))
+                .issuer(issuer.toString())
+                .notBeforeTime(new Date())
+                .issueTime(new Date())
+                .claim("nonce", code.getNonce());
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setIdToken(JWTClaimsSet idToken) {
+        this.idToken = idToken;
+    }
+
+    public void setIdToken(JWTClaimsSet.Builder idToken) {
+        this.idToken = idToken.build();
+    }
+
+    public void setAccessToken(JWTClaimsSet accessTokenJwt) {
+        this.accessTokenString = null;
+        this.accessTokenJwt = accessTokenJwt;
+    }
+
+    public void setAccessToken(JWTClaimsSet.Builder accessToken) {
+        setAccessToken(accessToken.build());
+    }
+
+    public void setAccessToken(String accessTokenString) {
+        this.accessTokenString = accessTokenString;
+        this.accessTokenJwt = null;
+    }
+}

--- a/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/Token.java
+++ b/openid-standalone-it/src/main/java/fish/payara/security/openid/idp/Token.java
@@ -97,11 +97,15 @@ public class Token {
         return new JWTClaimsSet.Builder()
                 .audience(code.getClientId())
                 .subject(subject)
-                .expirationTime(new Date(validityStart.plus(duration).toEpochMilli()))
+                .expirationTime(getExpirationTime())
                 .issuer(issuer.toString())
                 .notBeforeTime(new Date())
                 .issueTime(new Date())
                 .claim("nonce", code.getNonce());
+    }
+
+    public Date getExpirationTime() {
+        return new Date(validityStart.plus(duration).toEpochMilli());
     }
 
     public void setRefreshToken(String refreshToken) {

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AccessTokenRoleMapping.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AccessTokenRoleMapping.java
@@ -40,29 +40,20 @@
  *
  */
 
-package fish.payara.security.openid.idp;
+package fish.payara.security.openid.adfs;
 
-import java.io.File;
+import java.util.Collections;
+import java.util.Set;
 
-import fish.payara.security.connectors.openid.OpenIdExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import javax.enterprise.context.ApplicationScoped;
 
-public class OpenIdDeployment {
+import fish.payara.security.connectors.openid.api.AccessTokenCallerPrincipal;
+import fish.payara.security.connectors.openid.api.BearerGroupsIdentityStore;
 
-    public static WebArchive withAbstractProvider() {
-        return withAbstractProvider(ShrinkWrap.create(WebArchive.class));
-    }
-
-    public static WebArchive withAbstractProvider(WebArchive webArchive) {
-        File[] libs = Maven.resolver().loadPomFromFile("pom.xml")
-                .resolve("com.nimbusds:nimbus-jose-jwt")
-                .withTransitivity().asFile();
-        // maven resolver resolves version from bom, not the current snapshot, so we'll use this trick:
-        String openidStandaloneJar = OpenIdExtension.class.getProtectionDomain().getCodeSource().getLocation().getFile();
-        return webArchive.addPackage(AbstractIdProvider.class.getPackage())
-                .addAsLibraries(libs)
-                .addAsLibraries(new File(openidStandaloneJar));
+@ApplicationScoped
+public class AccessTokenRoleMapping extends BearerGroupsIdentityStore {
+    @Override
+    protected Set<String> getCallerGroups(AccessTokenCallerPrincipal accessTokenCallerPrincipal) {
+        return Collections.singleton("authenticated");
     }
 }

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AdfsEmulation.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AdfsEmulation.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.adfs;
+
+import java.net.URI;
+import java.util.Date;
+
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import fish.payara.security.openid.idp.AbstractIdProvider;
+import fish.payara.security.openid.idp.AuthCode;
+import fish.payara.security.openid.idp.Token;
+
+@Path("idp")
+public class AdfsEmulation extends AbstractIdProvider {
+    @Override
+    protected Object authenticate(AuthRequest request) throws AuthException {
+        return "testuser";
+    }
+
+    @Override
+    protected void customizeConfig(JsonObjectBuilder baseConfig, URI providerRoot) {
+        baseConfig.add("access_token_issuer", "http://someone-else");
+    }
+
+    @Override
+    protected Token exchangeToken(TokenRequest request) throws AuthException {
+        if ("gimme".equals(request.getGrantType())) {
+            Token result = new Token();
+            JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                    .audience("test_client")
+                    .subject("test_subject")
+                    .expirationTime(result.getExpirationTime())
+                    .issuer(providerRoot(uriInfo).toString())
+                    .notBeforeTime(new Date())
+                    .issueTime(new Date());
+            result.setIdToken(builder);
+            builder.issuer("http://someone-else");
+            result.setAccessToken(builder);
+            return result;
+        }
+        throw new AuthException("not_supported");
+    }
+
+    @Override
+    protected Token exchangeToken(AuthCode code) throws AuthException {
+        Token result = new Token();
+        result.setIdToken(result.claimsFor(code, providerRoot(uriInfo), "test_object"));
+        result.setAccessToken(result.claimsFor(code, URI.create("http://someone-else"), "test_object"));
+        return result;
+    }
+
+    @Override
+    protected JWT encodeJWT(JWTClaimsSet claims) throws JOSEException {
+        return rs256(claims);
+    }
+
+    @Override
+    protected JWKSet getKeyset() {
+        return new JWKSet(rsaKey());
+    }
+
+    @Override
+    protected JsonObject userInfo(Token token) {
+        throw new NotAuthorizedException("ADFS throws 401 here", (Response) null);
+    }
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AdfsEmulation.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/AdfsEmulation.java
@@ -43,6 +43,7 @@
 package fish.payara.security.openid.adfs;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Date;
 
 import javax.json.JsonObject;
@@ -93,7 +94,8 @@ public class AdfsEmulation extends AbstractIdProvider {
     @Override
     protected Token exchangeToken(AuthCode code) throws AuthException {
         Token result = new Token();
-        result.setIdToken(result.claimsFor(code, providerRoot(uriInfo), "test_object"));
+        result.setIdToken(result.claimsFor(code, providerRoot(uriInfo).resolve("idp/"), "test_object").claim("groups", Arrays.asList("authenticated",
+                "code_exchange")));
         result.setAccessToken(result.claimsFor(code, URI.create("http://someone-else"), "test_object"));
         return result;
     }
@@ -110,6 +112,6 @@ public class AdfsEmulation extends AbstractIdProvider {
 
     @Override
     protected JsonObject userInfo(Token token) {
-        throw new NotAuthorizedException("ADFS throws 401 here", (Response) null);
+        throw new NotAuthorizedException("ADFS throws 401 here", Response.status(401).build());
     }
 }

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/JaxrsApplication.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/JaxrsApplication.java
@@ -40,29 +40,12 @@
  *
  */
 
-package fish.payara.security.openid.idp;
+package fish.payara.security.openid.adfs;
 
-import java.io.File;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
 
-import fish.payara.security.connectors.openid.OpenIdExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+@ApplicationPath("")
+public class JaxrsApplication extends Application {
 
-public class OpenIdDeployment {
-
-    public static WebArchive withAbstractProvider() {
-        return withAbstractProvider(ShrinkWrap.create(WebArchive.class));
-    }
-
-    public static WebArchive withAbstractProvider(WebArchive webArchive) {
-        File[] libs = Maven.resolver().loadPomFromFile("pom.xml")
-                .resolve("com.nimbusds:nimbus-jose-jwt")
-                .withTransitivity().asFile();
-        // maven resolver resolves version from bom, not the current snapshot, so we'll use this trick:
-        String openidStandaloneJar = OpenIdExtension.class.getProtectionDomain().getCodeSource().getLocation().getFile();
-        return webArchive.addPackage(AbstractIdProvider.class.getPackage())
-                .addAsLibraries(libs)
-                .addAsLibraries(new File(openidStandaloneJar));
-    }
 }

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/OpenIdCallback.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/OpenIdCallback.java
@@ -43,36 +43,36 @@
 package fish.payara.security.openid.adfs;
 
 import java.security.Principal;
+import java.util.logging.Logger;
 
-import javax.annotation.security.DeclareRoles;
-import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
-import fish.payara.security.connectors.annotations.OpenIdAuthenticationDefinition;
-import fish.payara.security.connectors.annotations.OpenIdProviderMetadata;
+import fish.payara.security.connectors.openid.api.OpenIdContext;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("Callback")
 @RequestScoped
-@OpenIdAuthenticationDefinition(
-        clientId = "test_client",
-        clientSecret = "test_client",
-        providerURI = "#{urlExtractor.providerUrl}",
-        providerMetadata = @OpenIdProviderMetadata(
-                accessTokenIssuer = "http://someone-else"
-        ),
-        userClaimsFromIDToken = true
-)
-@Path("client")
-@RolesAllowed("authenticated")
-@DeclareRoles("authenticated")
-public class AdfsAuth {
+public class OpenIdCallback {
+    private static final Logger LOGGER = Logger.getLogger(OpenIdCallback.class.getName());
+
     @Inject
     Principal principal;
 
+    @Inject
+    OpenIdContext context;
+
     @GET
-    public String whoAmI() {
-        return principal.getName();
+    @Produces(APPLICATION_JSON)
+    public JsonArray userGroups() {
+        LOGGER.info("Request of " + principal.getName());
+        LOGGER.info("Request of " + context.getSubject());
+        return Json.createArrayBuilder(context.getCallerGroups()).build();
     }
 }

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/UrlExtractor.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/adfs/UrlExtractor.java
@@ -40,29 +40,24 @@
  *
  */
 
-package fish.payara.security.openid.idp;
+package fish.payara.security.openid.adfs;
 
-import java.io.File;
+import javax.enterprise.inject.Model;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 
-import fish.payara.security.connectors.openid.OpenIdExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+@Model
+public class UrlExtractor {
+    @Inject
+    HttpServletRequest request;
 
-public class OpenIdDeployment {
-
-    public static WebArchive withAbstractProvider() {
-        return withAbstractProvider(ShrinkWrap.create(WebArchive.class));
-    }
-
-    public static WebArchive withAbstractProvider(WebArchive webArchive) {
-        File[] libs = Maven.resolver().loadPomFromFile("pom.xml")
-                .resolve("com.nimbusds:nimbus-jose-jwt")
-                .withTransitivity().asFile();
-        // maven resolver resolves version from bom, not the current snapshot, so we'll use this trick:
-        String openidStandaloneJar = OpenIdExtension.class.getProtectionDomain().getCodeSource().getLocation().getFile();
-        return webArchive.addPackage(AbstractIdProvider.class.getPackage())
-                .addAsLibraries(libs)
-                .addAsLibraries(new File(openidStandaloneJar));
+    /**
+     * Used to determine IdP url at first protected request
+     *
+     * @return
+     */
+    public String getProviderUrl() {
+        StringBuffer uri = request.getRequestURL();
+        return uri.substring(0, uri.lastIndexOf("/")) + "/idp/";
     }
 }

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/LogExceptionOnServerSide.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/LogExceptionOnServerSide.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+public class LogExceptionOnServerSide implements TestWatcher {
+    private static final Logger LOGGER = Logger.getLogger(LogExceptionOnServerSide.class.getName());
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        LOGGER.log(Level.SEVERE, "Test failed: "+context.getTestClass().map(Class::getSimpleName).orElse("")+":"+context.getDisplayName(), cause);
+        TestWatcher.super.testFailed(context, cause);
+    }
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/OpenIdDeployment.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/OpenIdDeployment.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
+
+public class OpenIdDeployment {
+    public static WebArchive withAbstractProvider(WebArchive webArchive) {
+        File[] libs = Maven.resolver().loadPomFromFile("pom.xml")
+                .resolve("com.nimbusds:nimbus-jose-jwt", "fish.payara.security.connectors:openid-standalone")
+                .withTransitivity().asFile();
+        return webArchive.addPackage(AbstractIdProvider.class.getPackage())
+                .addAsLibraries(libs);
+    }
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/Callback.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/Callback.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp.simple;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import fish.payara.security.connectors.openid.api.OpenIdConstant;
+
+@Path("callback/")
+@RequestScoped
+public class Callback {
+    @GET
+    @Path("code")
+    @Produces("text/plain")
+    public String returnCode(@QueryParam(OpenIdConstant.CODE) String code) {
+        return code;
+    }
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/JaxrsApplication.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/JaxrsApplication.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp.simple;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("")
+public class JaxrsApplication extends Application {
+
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProvider.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProvider.java
@@ -49,9 +49,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
 import fish.payara.security.openid.idp.AbstractIdProvider;
 import fish.payara.security.openid.idp.AuthCode;
 import fish.payara.security.openid.idp.Token;
@@ -81,13 +82,18 @@ public class SimpleIdProvider extends AbstractIdProvider {
     }
 
     @Override
+    protected JWKSet getKeyset() {
+        return new JWKSet(rsaKey());
+    }
+
+    @Override
     protected Token exchangeToken(TokenRequest request) throws AuthException {
         throw new AuthException("not_supported");
     }
 
     @Override
-    protected JWT encodeJWT(JWTClaimsSet claims) {
-        return new PlainJWT(claims);
+    protected JWT encodeJWT(JWTClaimsSet claims) throws JOSEException {
+        return rs256(claims);
     }
 
     @Override

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProvider.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProvider.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp.simple;
+
+import javax.enterprise.context.RequestScoped;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
+import fish.payara.security.openid.idp.AbstractIdProvider;
+import fish.payara.security.openid.idp.AuthCode;
+import fish.payara.security.openid.idp.Token;
+
+@Path("simple/")
+@RequestScoped
+public class SimpleIdProvider extends AbstractIdProvider {
+    public static final String CLIENT_ID = "test_client";
+
+    @Context
+    UriInfo uri;
+
+    @Override
+    protected Object authenticate(AuthRequest request) throws AuthException {
+        if (CLIENT_ID.equals(request.getClientId())) {
+            return "testuser";
+        }
+        throw new AuthException("invalid_credentials");
+    }
+
+    @Override
+    protected Token exchangeToken(AuthCode code) throws AuthException {
+        Token token = new Token();
+        token.setIdToken(token.claimsFor(code, providerRoot(uri), String.valueOf(code.getIdentity())));
+        token.setAccessToken("accesstoken");
+        return token;
+    }
+
+    @Override
+    protected Token exchangeToken(TokenRequest request) throws AuthException {
+        throw new AuthException("not_supported");
+    }
+
+    @Override
+    protected JWT encodeJWT(JWTClaimsSet claims) {
+        return new PlainJWT(claims);
+    }
+
+    @Override
+    protected JsonObject userInfo(Token token) {
+        return JsonValue.EMPTY_JSON_OBJECT;
+    }
+}

--- a/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProviderIT.java
+++ b/openid-standalone-it/src/test/java/fish/payara/security/openid/idp/simple/SimpleIdProviderIT.java
@@ -1,0 +1,152 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+
+package fish.payara.security.openid.idp.simple;
+
+import java.net.URI;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+
+import fish.payara.security.openid.idp.LogExceptionOnServerSide;
+import fish.payara.security.openid.idp.OpenIdDeployment;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.CLIENT_ID;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.CODE;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.GRANT_TYPE;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.NONCE;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.REDIRECT_URI;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.RESPONSE_TYPE;
+import static fish.payara.security.connectors.openid.api.OpenIdConstant.SCOPE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates that AbstractIdProvider behaves as expected for the simplest case without actually using connector.
+ */
+@ExtendWith(ArquillianExtension.class)
+@ExtendWith(LogExceptionOnServerSide.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SimpleIdProviderIT {
+    @Deployment
+    public static WebArchive deployment() {
+        return OpenIdDeployment.withAbstractProvider(ShrinkWrap.create(WebArchive.class))
+                .addClasses(SimpleIdProvider.class, Callback.class).addClass(JaxrsApplication.class);
+    }
+
+    @ArquillianResource
+    URI baseUri;
+
+    private static final Logger LOGGER = Logger.getLogger(SimpleIdProviderIT.class.getName());
+
+    private JsonObject config;
+
+    @BeforeEach
+    public void fetchConfig() {
+        // Before/After All is executed on client side, but these are executed server-side
+        if (config != null) {
+            return;
+        }
+        WebTarget target = ClientBuilder.newClient().target(baseUri).path("simple/.well-known/openid-configuration");
+        LOGGER.info("Will request " + target.getUri());
+        config = target.request(MediaType.APPLICATION_JSON).get(JsonObject.class);
+    }
+
+    @Test
+    public void deploys() {
+        assertNotNull(config);
+        LOGGER.info(config.toString());
+    }
+
+    @Test
+    public void endpointUrisAreAbsolute() {
+        assertTrue(config.getString("authorization_endpoint").startsWith("http"));
+        assertTrue(config.getString("token_endpoint").startsWith("http"));
+    }
+
+    @Test
+    public void codeExchangeFlowWorks() {
+        Client client = ClientBuilder.newClient().register(new LoggingFeature(LOGGER,
+                Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 10000));
+        String nonce = "123098";
+        // the relying party sends client to idp authorization endpoint
+        String code = client.target(config.getString("authorization_endpoint"))
+                .queryParam(CLIENT_ID, SimpleIdProvider.CLIENT_ID)
+                .queryParam(REDIRECT_URI, baseUri.resolve("callback/code"))
+                .queryParam(NONCE, nonce)
+                .queryParam(RESPONSE_TYPE, "code")
+                .queryParam(SCOPE, "openid")
+                .request().get(String.class);
+        // idp redirects to callback endpoint of relying party
+        assertNotNull(code);
+        // relaying party obtains the tokens
+        Form tokenRequest = new Form();
+        tokenRequest.param(GRANT_TYPE, "authorization_code")
+                .param(CLIENT_ID, SimpleIdProvider.CLIENT_ID)
+                .param(CODE, code);
+        JsonObject token = client.target(config.getString("token_endpoint"))
+                .request()
+                .post(Entity.form(tokenRequest), JsonObject.class);
+        String accessToken = token.getString("access_token");
+        JsonObject userinfo = client.target(config.getString("userinfo_endpoint"))
+                .request().header("Authorization", "Bearer " + accessToken)
+                .get(JsonObject.class);
+        assertNotNull(userinfo);
+    }
+}

--- a/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
+++ b/openid/src/main/java/fish/payara/security/openid/AccessTokenIdentityStore.java
@@ -126,7 +126,7 @@ public class AccessTokenIdentityStore implements IdentityStore {
         public void verify(JWTClaimsSet claims, SecurityContext c) throws BadJWTException {
             StandardVerifications standardVerifications = new StandardVerifications(configuration, claims);
 
-            standardVerifications.requireSameIssuer();
+            standardVerifications.requireIssuer(configuration.getProviderMetadata().getAccessTokenIssuerURI());
             standardVerifications.requireSubject();
             standardVerifications.requireValidTimestamp();
             // Validating audience is left to application now. We generally expect that we'll accept the token from

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -196,12 +196,17 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         if (isNull(request.getUserPrincipal())) {
             LOGGER.fine("UserPrincipal is not set, authenticate user using OpenId Connect protocol.");
-            if (httpContext.isProtected() && hasBearerAuthorization(request)) {
-                return authenticateBearer(request, response, httpContext);
+            if (httpContext.isProtected()) {
+                if (hasBearerAuthorization(request)) {
+                    return authenticateBearer(request, response, httpContext);
+                } else {
+                    // User is not authenticated
+                    // Perform steps (1) to (6)
+                    return this.authenticate(request, response, httpContext);
+                }
+            } else {
+                return httpContext.doNothing();
             }
-            // User is not authenticated
-            // Perform steps (1) to (6)
-            return this.authenticate(request, response, httpContext);
         } else {
             // User has been authenticated in request before
 

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -79,6 +79,7 @@ import fish.payara.security.openid.domain.OpenIdContextImpl;
 import fish.payara.security.openid.domain.RefreshTokenImpl;
 
 import static fish.payara.security.openid.OpenIdUtil.isEmpty;
+import static fish.payara.security.openid.api.OpenIdConstant.CODE;
 import static fish.payara.security.openid.api.OpenIdConstant.ERROR_DESCRIPTION_PARAM;
 import static fish.payara.security.openid.api.OpenIdConstant.ERROR_PARAM;
 import static fish.payara.security.openid.api.OpenIdConstant.EXPIRES_IN;
@@ -196,17 +197,12 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
 
         if (isNull(request.getUserPrincipal())) {
             LOGGER.fine("UserPrincipal is not set, authenticate user using OpenId Connect protocol.");
-            if (httpContext.isProtected()) {
-                if (hasBearerAuthorization(request)) {
-                    return authenticateBearer(request, response, httpContext);
-                } else {
-                    // User is not authenticated
-                    // Perform steps (1) to (6)
-                    return this.authenticate(request, response, httpContext);
-                }
-            } else {
-                return httpContext.doNothing();
+            if (httpContext.isProtected() && hasBearerAuthorization(request)) {
+                return authenticateBearer(request, response, httpContext);
             }
+            // User is not authenticated, and this potentially may be an OAuth callback
+            // Perform steps (1) to (6)
+            return this.authenticate(request, response, httpContext);
         } else {
             // User has been authenticated in request before
 
@@ -290,11 +286,17 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
             return authenticationController.authenticateUser(request, response);
         }
 
+        // Check if the request is potential OAuth callback
+        if (!"GET".equals(request.getMethod())) {
+            return httpContext.doNothing();
+        }
         Optional<OpenIdState> receivedState = OpenIdState.from(request.getParameter(STATE));
-        String redirectURI = configuration.buildRedirectURI(request);
-        if (receivedState.isPresent()) {
+        if (receivedState.isPresent() && request.getParameter(CODE) != null) {
+            // this is OAuth callback
+            String redirectURI = configuration.buildRedirectURI(request);
             if (!request.getRequestURL().toString().equals(redirectURI)) {
-                LOGGER.log(INFO, "OpenID Redirect URL {0} not matched with request URL {1}", new Object[]{redirectURI, request.getRequestURL().toString()});
+                LOGGER.log(INFO, "OpenID Redirect URL {0} not matched with request URL {1}", new Object[]{redirectURI,
+                        request.getRequestURL().toString()});
                 return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
             }
             Optional<OpenIdState> expectedState = stateController.get(request, response);

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -218,6 +218,8 @@ public class ConfigurationController implements Serializable {
         String extraParamsRaw = OpenIdUtil.getConfiguredValue(String.class, extraParametersFromAnnotation, provider, OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW);
         Map<String, List<String>> extraParameters = parseMultiMapFromUrlQuery(extraParamsRaw);
         boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, providerMetadata.disableScopeValidation(), provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
+        String accessTokenIssuerURI = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.accessTokenIssuer(), provider,
+                OpenIdProviderMetadata.OPENID_MP_ACCESS_TOKEN_ISSUER);
 
         fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
                 providerDocument,
@@ -233,7 +235,8 @@ public class ConfigurationController implements Serializable {
                 .setTokenEndpoint(tokenEndpoint)
                 .setUserinfoEndpoint(userinfoEndpoint)
                 .setEndSessionEndpoint(endSessionEndpoint)
-                .setJwksURL(jwksURL);
+                .setJwksURL(jwksURL)
+                .setAccessTokenIssuerURI(accessTokenIssuerURI);
 
         OpenIdConfiguration configuration = new OpenIdConfiguration()
                 .setProviderMetadata(

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -37,24 +37,20 @@
  */
 package fish.payara.security.openid.controller;
 
-import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
-import fish.payara.security.annotations.OpenIdProviderMetadata;
-import fish.payara.security.openid.api.PromptType;
-import fish.payara.security.openid.domain.ClaimsConfiguration;
-import fish.payara.security.openid.domain.LogoutConfiguration;
-import fish.payara.security.openid.domain.OpenIdConfiguration;
-import fish.payara.security.openid.domain.OpenIdTokenEncryptionMetadata;
-
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.joining;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
@@ -63,16 +59,20 @@ import javax.json.JsonObject;
 
 import fish.payara.security.annotations.ClaimsDefinition;
 import fish.payara.security.annotations.LogoutDefinition;
+import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
+import fish.payara.security.annotations.OpenIdProviderMetadata;
 import fish.payara.security.openid.OpenIdAuthenticationException;
 import fish.payara.security.openid.OpenIdUtil;
 import fish.payara.security.openid.api.OpenIdConstant;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import fish.payara.security.openid.api.PromptType;
+import fish.payara.security.openid.domain.ClaimsConfiguration;
+import fish.payara.security.openid.domain.LogoutConfiguration;
+import fish.payara.security.openid.domain.OpenIdConfiguration;
+import fish.payara.security.openid.domain.OpenIdTokenEncryptionMetadata;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Build and validate the OpenId Connect client configuration
@@ -207,21 +207,31 @@ public class ConfigurationController implements Serializable {
         String callerNameClaim = OpenIdUtil.getConfiguredValue(String.class, definition.claimsDefinition().callerNameClaim(), provider, ClaimsDefinition.OPENID_MP_CALLER_NAME_CLAIM);
         String callerGroupsClaim = OpenIdUtil.getConfiguredValue(String.class, definition.claimsDefinition().callerGroupsClaim(), provider, ClaimsDefinition.OPENID_MP_CALLER_GROUP_CLAIM);
 
-        Boolean notifyProvider = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().notifyProvider(), provider, LogoutDefinition.OPENID_MP_PROVIDER_NOTIFY_LOGOUT);
-        String logoutRedirectURI = OpenIdUtil.getConfiguredValue(String.class, definition.logout().redirectURI(), provider, LogoutDefinition.OPENID_MP_POST_LOGOUT_REDIRECT_URI);
-        Boolean accessTokenExpiry = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().accessTokenExpiry(), provider, LogoutDefinition.OPENID_MP_LOGOUT_ON_ACCESS_TOKEN_EXPIRY);
-        Boolean identityTokenExpiry = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().identityTokenExpiry(), provider, LogoutDefinition.OPENID_MP_LOGOUT_ON_IDENTITY_TOKEN_EXPIRY);
+        Boolean notifyProvider = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().notifyProvider(), provider,
+                LogoutDefinition.OPENID_MP_PROVIDER_NOTIFY_LOGOUT);
+        String logoutRedirectURI = OpenIdUtil.getConfiguredValue(String.class, definition.logout().redirectURI(), provider,
+                LogoutDefinition.OPENID_MP_POST_LOGOUT_REDIRECT_URI);
+        Boolean accessTokenExpiry = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().accessTokenExpiry(), provider,
+                LogoutDefinition.OPENID_MP_LOGOUT_ON_ACCESS_TOKEN_EXPIRY);
+        Boolean identityTokenExpiry = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().identityTokenExpiry(), provider,
+                LogoutDefinition.OPENID_MP_LOGOUT_ON_IDENTITY_TOKEN_EXPIRY);
 
-        boolean tokenAutoRefresh = OpenIdUtil.getConfiguredValue(Boolean.class, definition.tokenAutoRefresh(), provider, OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_AUTO_REFRESH);
-        int tokenMinValidity = OpenIdUtil.getConfiguredValue(Integer.class, definition.tokenMinValidity(), provider, OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_MIN_VALIDITY);
-        boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider, OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
-        String extraParamsRaw = OpenIdUtil.getConfiguredValue(String.class, extraParametersFromAnnotation, provider, OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW);
+        boolean tokenAutoRefresh = OpenIdUtil.getConfiguredValue(Boolean.class, definition.tokenAutoRefresh(), provider,
+                OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_AUTO_REFRESH);
+        int tokenMinValidity = OpenIdUtil.getConfiguredValue(Integer.class, definition.tokenMinValidity(), provider,
+                OpenIdAuthenticationDefinition.OPENID_MP_TOKEN_MIN_VALIDITY);
+        boolean userClaimsFromIDToken = OpenIdUtil.getConfiguredValue(Boolean.class, definition.userClaimsFromIDToken(), provider,
+                OpenIdAuthenticationDefinition.OPENID_MP_USER_CLAIMS_FROM_ID_TOKEN);
+        String extraParamsRaw = OpenIdUtil.getConfiguredValue(String.class, extraParametersFromAnnotation, provider,
+                OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW);
         Map<String, List<String>> extraParameters = parseMultiMapFromUrlQuery(extraParamsRaw);
-        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, providerMetadata.disableScopeValidation(), provider, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
+        boolean disableScopeValidation = OpenIdUtil.getConfiguredValue(Boolean.class, providerMetadata.disableScopeValidation(), provider,
+                OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION);
         String accessTokenIssuerURI = OpenIdUtil.getConfiguredValue(String.class, providerMetadata.accessTokenIssuer(), provider,
                 OpenIdProviderMetadata.OPENID_MP_ACCESS_TOKEN_ISSUER);
 
-        fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata = new fish.payara.security.openid.domain.OpenIdProviderMetadata(
+        fish.payara.security.openid.domain.OpenIdProviderMetadata openIdProviderMetadata =
+                new fish.payara.security.openid.domain.OpenIdProviderMetadata(
                 providerDocument,
                 issuerURI,
                 scopesSupported,

--- a/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/TokenClaimsSetVerifier.java
@@ -37,16 +37,16 @@
  */
 package fish.payara.security.openid.controller;
 
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
-import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.api.OpenIdConstant;
-
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import fish.payara.security.openid.domain.OpenIdConfiguration;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -83,7 +83,16 @@ public abstract class TokenClaimsSetVerifier implements JWTClaimsSetVerifier {
                 throw new IllegalStateException("Missing issuer (iss) claim");
             }
             if (!claims.getIssuer().equals(configuration.getProviderMetadata().getIssuerURI())) {
-                throw new IllegalStateException("Invalid issuer : " + configuration.getProviderMetadata().getIssuerURI());
+                throw new IllegalStateException("Invalid issuer : " + claims.getIssuer());
+            }
+        }
+
+        public void requireIssuer(String issuer) {
+            if (isNull(claims.getIssuer())) {
+                throw new IllegalStateException("Missing issuer (iss) claim");
+            }
+            if (!claims.getIssuer().equals(issuer)) {
+                throw new IllegalStateException("Invalid issuer : " + claims.getIssuer());
             }
         }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -38,11 +38,10 @@
 package fish.payara.security.openid.domain;
 
 import java.util.Arrays;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-
-import fish.payara.security.openid.controller.JWTValidator;
 import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * OpenId Connect client configuration
@@ -70,7 +69,6 @@ public class OpenIdConfiguration {
     private LogoutConfiguration logoutConfiguration;
     private boolean tokenAutoRefresh;
     private int tokenMinValidity;
-    private JWTValidator validator;
     private boolean userClaimsFromIDToken;
     private boolean disableScopeValidation;
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdProviderMetadata.java
@@ -39,6 +39,7 @@ package fish.payara.security.openid.domain;
 
 import java.net.URL;
 import java.util.Set;
+
 import javax.json.JsonObject;
 
 /**
@@ -53,17 +54,31 @@ public class OpenIdProviderMetadata {
     private String authorizationEndpoint;
     private String tokenEndpoint;
     private String userinfoEndpoint;
+
     private String endSessionEndpoint;
+
     private URL jwksURL;
+
     private final Set<String> scopesSupported;
+
     private final Set<String> claimsSupported;
+
     private final Set<String> responseTypesSupported;
+
     private final Set<String> idTokenSigningAlgValuesSupported;
+
     private final Set<String> idTokenEncryptionAlgValuesSupported;
+
     private final Set<String> idTokenEncryptionEncValuesSupported;
+
     private final Set<String> subjectTypesSupported;
 
-    public OpenIdProviderMetadata(JsonObject providerDocument, String issuerURI, Set<String> scopesSupported, Set<String> claimsSupported, Set<String> responseTypesSupported, Set<String> idTokenSigningAlgValuesSupported, Set<String> idTokenEncryptionAlgValuesSupported, Set<String> idTokenEncryptionEncValuesSupported, Set<String> subjectTypesSupported) {
+    private String accessTokenIssuerURI;
+
+    public OpenIdProviderMetadata(JsonObject providerDocument, String issuerURI, Set<String> scopesSupported, Set<String> claimsSupported,
+                                  Set<String> responseTypesSupported, Set<String> idTokenSigningAlgValuesSupported,
+                                  Set<String> idTokenEncryptionAlgValuesSupported, Set<String> idTokenEncryptionEncValuesSupported,
+                                  Set<String> subjectTypesSupported) {
         this.document = providerDocument;
         this.issuerURI = issuerURI;
         this.scopesSupported = scopesSupported;
@@ -161,6 +176,22 @@ public class OpenIdProviderMetadata {
         return idTokenEncryptionEncValuesSupported;
     }
 
+    public String getAccessTokenIssuerURI() {
+        if (accessTokenIssuerURI == null) {
+            return issuerURI;
+        }
+        return accessTokenIssuerURI;
+    }
+
+    public OpenIdProviderMetadata setAccessTokenIssuerURI(String accessTokenIssuerURI) {
+        if (accessTokenIssuerURI != null && !accessTokenIssuerURI.isEmpty()) {
+            this.accessTokenIssuerURI = accessTokenIssuerURI;
+        } else {
+            this.accessTokenIssuerURI = null;
+        }
+        return this;
+    }
+
     @Override
     public String toString() {
         return OpenIdProviderMetadata.class.getSimpleName()
@@ -170,6 +201,7 @@ public class OpenIdProviderMetadata {
                 + ", tokenEndpoint=" + tokenEndpoint
                 + ", userinfoEndpoint=" + userinfoEndpoint
                 + ", jwksURI=" + jwksURL
+                + ", accessTokenIssuerURI=" + accessTokenIssuerURI
                 + '}';
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <module>openid</module>
         <module>oauth2</module>
         <module>openid-standalone</module>
+        <module>openid-standalone-it</module>
     </modules>
 
     <properties>
@@ -350,16 +351,14 @@
 
     <repositories>
         <repository>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <!--<url>file:///opt/PayaraDev/Payara_PatchedProjects</url>-->
             <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts</url>
         </repository>
     </repositories>
 </project>

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdProviderMetadata.java
@@ -38,6 +38,7 @@
 package fish.payara.security.annotations;
 
 import java.lang.annotation.Retention;
+
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -87,7 +88,8 @@ public @interface OpenIdProviderMetadata {
     String tokenEndpoint() default "";
 
     /**
-     * Required: An OAuth 2.0 Protected Resource that returns Claims about the     * authenticated End-User.
+     * Required: An OAuth 2.0 Protected Resource that returns Claims about the
+     * authenticated End-User.
      * <p>
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.userinfoEndpoint}
@@ -98,7 +100,8 @@ public @interface OpenIdProviderMetadata {
     String userinfoEndpoint() default "";
 
     /**
-     * Optional: OP endpoint to notify that the End-User has logged out of the     * site and might want to log out of the OP as well.
+     * Optional: OP endpoint to notify that the End-User has logged out of the
+     * site and might want to log out of the OP as well.
      * <p>
      * To set this using Microprofile Config use
      * {@code payara.security.openid.provider.endSessionEndpoint}
@@ -217,6 +220,16 @@ public @interface OpenIdProviderMetadata {
     boolean disableScopeValidation() default false;
 
     /**
+     * Specify issuer of Access Token to validate against. Microsoft Active Directory Federation Services (ADFS) is known
+     * to use different issuer for its access token, this value must be configured so access token validations would pass.
+     * <p>
+     * To set this using Microrprofile config use <code>{@value #OPENID_MP_ACCESS_TOKEN_ISSUER}</code>
+     *
+     * @return
+     */
+    String accessTokenIssuer() default "";
+
+    /**
      * The Microprofile Config key for the issuer url is <code>{@value}</code>.
      */
     String OPENID_MP_ISSUER = "payara.security.openid.provider.issuer";
@@ -281,5 +294,10 @@ public @interface OpenIdProviderMetadata {
      * The Microprofile Config key for the supported claims supported is <code>{@value}</code>
      */
     String OPENID_MP_CLAIMS_SUPPORTED = "payara.security.openid.provider.claimsSupported";
+
+    /**
+     * The Microprofile Config key for non-standard Access Token Issuer is <code>@{value}</code>
+     */
+    String OPENID_MP_ACCESS_TOKEN_ISSUER = "payara.security.openid.provider.accessTokenIssuer";
 
 }


### PR DESCRIPTION
* added suite for testing OpenID features with Arquillian
* added test cases for ADFS behavior
* Fixed code paths, so that it is possible to include both IDP and client in single application
** Initialization of OpenId is postponed due to better heuristics of whether a request is an OAuth callback