### PR TITLE
FISH-8054 Proxy Support in OpenID Security Connector

### DIFF
--- a/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
@@ -52,6 +52,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import static fish.payara.security.annotations.AzureAuthenticationDefinition.OPENID_MP_AZURE_TENANT_ID;
 import static fish.payara.security.openid.OpenIdUtil.getConfiguredValue;
 import static fish.payara.security.openid.OpenIdUtil.isEmpty;
+import fish.payara.security.annotations.ProxyDefinition;
 
 /**
  * Interpret {@link AzureAuthenticationDefinition}
@@ -83,6 +84,11 @@ public class AzureDefinitionConverter {
             @Override
             public ClaimsDefinition claimsDefinition() {
                 return azureDefinition.claimsDefinition();
+            }
+
+            @Override
+            public ProxyDefinition proxyDefinition() {
+                return azureDefinition.proxyDefinition();
             }
 
             @Override

--- a/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
@@ -46,6 +46,7 @@ import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
 import fish.payara.security.annotations.OpenIdProviderMetadata;
 import fish.payara.security.openid.api.DisplayType;
 import fish.payara.security.openid.api.PromptType;
+import fish.payara.security.annotations.ProxyDefinition;
 
 /**
  * Translates GoogleAuthenticationDefinition to OpenIdAuthenticationDefinition
@@ -71,6 +72,11 @@ public class GoogleDefinitionConverter {
             @Override
             public ClaimsDefinition claimsDefinition() {
                 return googleDefinition.claimsDefinition();
+            }
+
+            @Override
+            public ProxyDefinition proxyDefinition() {
+                return googleDefinition.proxyDefinition();
             }
 
             @Override

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdAuthenticationMechanism.java
@@ -295,6 +295,29 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
             // this is OAuth callback
             String redirectURI = configuration.buildRedirectURI(request);
             if (!request.getRequestURL().toString().equals(redirectURI)) {
+                if (configuration.getProxyConfiguration() != null && !configuration.getProxyConfiguration().getHostName().isEmpty()) {
+                    // Check if request URL matches proxy host name and port
+                    String proxyHost = configuration.getProxyConfiguration().getHostName();
+                    String proxyPort = configuration.getProxyConfiguration().getPort();
+
+                    String requestURLWithProxy;
+                    if (!proxyPort.isEmpty()) {
+                        requestURLWithProxy = String.format("%s://%s:%s", request.getScheme(), proxyHost, proxyPort) + request.getRequestURI();
+                    } else {
+                        requestURLWithProxy = String.format("%s://%s", request.getScheme(), proxyHost) + request.getRequestURI();
+                    }
+                    if (!requestURLWithProxy.equals(request.getRequestURL().toString())) {
+                        LOGGER.log(INFO, "OpenID Redirect URL {0} does not match with the request URL {1} through proxy {2}:{3}",
+                                new Object[]{redirectURI, requestURLWithProxy, proxyHost, proxyPort});
+                        return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
+                    }
+                } else {
+                    LOGGER.log(INFO, "OpenID Redirect URL {0} does not match with the request URL {1}",
+                            new Object[]{redirectURI, request.getRequestURL().toString()});
+                    return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);
+                }
+            }
+            if (!request.getRequestURL().toString().equals(redirectURI)) {
                 LOGGER.log(INFO, "OpenID Redirect URL {0} not matched with request URL {1}", new Object[]{redirectURI,
                         request.getRequestURL().toString()});
                 return httpContext.notifyContainerAboutLogin(NOT_VALIDATED_RESULT);

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -69,10 +69,12 @@ import fish.payara.security.openid.domain.ClaimsConfiguration;
 import fish.payara.security.openid.domain.LogoutConfiguration;
 import fish.payara.security.openid.domain.OpenIdConfiguration;
 import fish.payara.security.openid.domain.OpenIdTokenEncryptionMetadata;
+import fish.payara.security.openid.domain.ProxyConfiguration;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import static java.util.stream.Collectors.joining;
+import fish.payara.security.annotations.ProxyDefinition;
 
 /**
  * Build and validate the OpenId Connect client configuration
@@ -207,6 +209,9 @@ public class ConfigurationController implements Serializable {
         String callerNameClaim = OpenIdUtil.getConfiguredValue(String.class, definition.claimsDefinition().callerNameClaim(), provider, ClaimsDefinition.OPENID_MP_CALLER_NAME_CLAIM);
         String callerGroupsClaim = OpenIdUtil.getConfiguredValue(String.class, definition.claimsDefinition().callerGroupsClaim(), provider, ClaimsDefinition.OPENID_MP_CALLER_GROUP_CLAIM);
 
+        String proxyHostName = OpenIdUtil.getConfiguredValue(String.class, definition.proxyDefinition().hostName(), provider, ProxyDefinition.OPENID_MP_PROXY_HOSTNAME);
+        String proxyPort = OpenIdUtil.getConfiguredValue(String.class, definition.proxyDefinition().port(), provider, ProxyDefinition.OPENID_MP_PROXY_PORT);
+
         Boolean notifyProvider = OpenIdUtil.getConfiguredValue(Boolean.class, definition.logout().notifyProvider(), provider,
                 LogoutDefinition.OPENID_MP_PROVIDER_NOTIFY_LOGOUT);
         String logoutRedirectURI = OpenIdUtil.getConfiguredValue(String.class, definition.logout().redirectURI(), provider,
@@ -256,6 +261,9 @@ public class ConfigurationController implements Serializable {
                         new ClaimsConfiguration()
                                 .setCallerNameClaim(callerNameClaim)
                                 .setCallerGroupsClaim(callerGroupsClaim)
+                ).setProxyConfiguration(new ProxyConfiguration()
+                                .setHostName(proxyHostName)
+                                .setPort(proxyPort)
                 ).setLogoutConfiguration(
                         new LogoutConfiguration()
                                 .setNotifyProvider(notifyProvider)
@@ -474,6 +482,7 @@ public class ConfigurationController implements Serializable {
                 definition.extraParameters(),
                 providerMetadataAttrs(definition.providerMetadata()),
                 claimsAttrs(definition.claimsDefinition()),
+                proxyAttrs(definition.proxyDefinition()),
                 logoutAttrs(definition.logout())
         };
 
@@ -494,6 +503,13 @@ public class ConfigurationController implements Serializable {
         return claimsDefinition != null ? new String[] {
                 claimsDefinition.callerGroupsClaim(),
                 claimsDefinition.callerNameClaim()
+        } : new String[2];
+    }
+    
+    private static String[] proxyAttrs(ProxyDefinition proxyDefinition) {
+        return proxyDefinition != null ? new String[]{
+            proxyDefinition.hostName(),
+            proxyDefinition.port()
         } : new String[2];
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/LogoutConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/LogoutConfiguration.java
@@ -75,16 +75,19 @@ public class LogoutConfiguration {
    public String buildRedirectURI(ProxyConfiguration proxyConfiguration, HttpServletRequest request) {
         String uri = redirectURI;
         if (redirectURI.contains(BASE_URL_EXPRESSION)) {
-            String baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
-                    + request.getContextPath();
+            String baseURL;
+            if (proxyConfiguration != null
+                    && !proxyConfiguration.getHostName().isEmpty()) {
+                baseURL = request.getScheme() + "://" + proxyConfiguration.getHostName();
+                if (!proxyConfiguration.getPort().isEmpty()) {
+                    baseURL = baseURL + ":" + proxyConfiguration.getPort();
+                }
+                baseURL = baseURL + request.getContextPath();
+            } else {
+                baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
+                        + request.getContextPath();
+            }
             uri = redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
-        }
-        
-        if (proxyConfiguration != null
-                && !proxyConfiguration.getHostName().isEmpty()
-                && !proxyConfiguration.getPort().isEmpty()) {
-            uri = uri.replace(request.getServerName(), proxyConfiguration.getHostName());
-            uri = uri.replace(String.valueOf(request.getServerPort()), proxyConfiguration.getPort());
         }
         return uri;
     }

--- a/openid/src/main/java/fish/payara/security/openid/domain/LogoutConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/LogoutConfiguration.java
@@ -72,13 +72,21 @@ public class LogoutConfiguration {
         return this;
     }
 
-    public String buildRedirectURI(HttpServletRequest request) {
+   public String buildRedirectURI(ProxyConfiguration proxyConfiguration, HttpServletRequest request) {
+        String uri = redirectURI;
         if (redirectURI.contains(BASE_URL_EXPRESSION)) {
             String baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
                     + request.getContextPath();
-            return redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
+            uri = redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
         }
-        return redirectURI;
+        
+        if (proxyConfiguration != null
+                && !proxyConfiguration.getHostName().isEmpty()
+                && !proxyConfiguration.getPort().isEmpty()) {
+            uri = uri.replace(request.getServerName(), proxyConfiguration.getHostName());
+            uri = uri.replace(String.valueOf(request.getServerPort()), proxyConfiguration.getPort());
+        }
+        return uri;
     }
 
     public boolean isAccessTokenExpiry() {

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -66,6 +66,7 @@ public class OpenIdConfiguration {
     private OpenIdProviderMetadata providerMetadata;
     private OpenIdTokenEncryptionMetadata encryptionMetadata;
     private ClaimsConfiguration claimsConfiguration;
+    private ProxyConfiguration proxyConfiguration;
     private LogoutConfiguration logoutConfiguration;
     private boolean tokenAutoRefresh;
     private int tokenMinValidity;
@@ -93,12 +94,20 @@ public class OpenIdConfiguration {
     }
 
     public String buildRedirectURI(HttpServletRequest request) {
+        String uri = redirectURI;
         if (redirectURI.contains(BASE_URL_EXPRESSION)) {
             String baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
                     + request.getContextPath();
-            return redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
+            uri = redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
         }
-        return redirectURI;
+        
+        if (proxyConfiguration != null
+                && !proxyConfiguration.getHostName().isEmpty()
+                && !proxyConfiguration.getPort().isEmpty()) {
+            uri = uri.replace(request.getServerName(), proxyConfiguration.getHostName());
+            uri = uri.replace(String.valueOf(request.getServerPort()), proxyConfiguration.getPort());
+        }
+        return uri;
     }
 
     public String getRedirectURI() {
@@ -215,6 +224,15 @@ public class OpenIdConfiguration {
 
     public OpenIdConfiguration setClaimsConfiguration(ClaimsConfiguration claimsConfiguration) {
         this.claimsConfiguration = claimsConfiguration;
+        return this;
+    }
+
+    public ProxyConfiguration getProxyConfiguration() {
+        return proxyConfiguration;
+    }
+
+    public OpenIdConfiguration setProxyConfiguration(ProxyConfiguration proxyConfiguration) {
+        this.proxyConfiguration = proxyConfiguration;
         return this;
     }
 

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdConfiguration.java
@@ -96,16 +96,19 @@ public class OpenIdConfiguration {
     public String buildRedirectURI(HttpServletRequest request) {
         String uri = redirectURI;
         if (redirectURI.contains(BASE_URL_EXPRESSION)) {
-            String baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
-                    + request.getContextPath();
+            String baseURL;
+            if (proxyConfiguration != null
+                    && !proxyConfiguration.getHostName().isEmpty()) {
+                baseURL = request.getScheme() + "://" + proxyConfiguration.getHostName();
+                if (!proxyConfiguration.getPort().isEmpty()) {
+                    baseURL = baseURL + ":" + proxyConfiguration.getPort();
+                }
+                baseURL = baseURL + request.getContextPath();
+            } else {
+                baseURL = request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length())
+                        + request.getContextPath();
+            }
             uri = redirectURI.replace(BASE_URL_EXPRESSION, baseURL);
-        }
-        
-        if (proxyConfiguration != null
-                && !proxyConfiguration.getHostName().isEmpty()
-                && !proxyConfiguration.getPort().isEmpty()) {
-            uri = uri.replace(request.getServerName(), proxyConfiguration.getHostName());
-            uri = uri.replace(String.valueOf(request.getServerPort()), proxyConfiguration.getPort());
         }
         return uri;
     }

--- a/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/OpenIdContextImpl.java
@@ -239,11 +239,11 @@ public class OpenIdContextImpl implements OpenIdContext {
                     .queryParam(OpenIdConstant.ID_TOKEN_HINT, getIdentityToken().getToken());
             if (!OpenIdUtil.isEmpty(logout.getRedirectURI())) {
                 // User Agent redirected to POST_LOGOUT_REDIRECT_URI after a logout operation performed in OP.
-                logoutURI.queryParam(OpenIdConstant.POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
+                logoutURI.queryParam(OpenIdConstant.POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(configuration.getProxyConfiguration(), request));
             }
             redirect(response, logoutURI.build().toASCIIString());
         } else if (!OpenIdUtil.isEmpty(logout.getRedirectURI())) {
-            redirect(response, logout.buildRedirectURI(request));
+            redirect(response, logout.buildRedirectURI(configuration.getProxyConfiguration(), request));
         } else {
             // Redirect user to OpenID connect provider for re-authentication
             authenticationController.authenticateUser(request, response);

--- a/openid/src/main/java/fish/payara/security/openid/domain/ProxyConfiguration.java
+++ b/openid/src/main/java/fish/payara/security/openid/domain/ProxyConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.openid.domain;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class ProxyConfiguration {
+
+    private String hostName;
+    private String port;
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public ProxyConfiguration setHostName(String hostName) {
+        this.hostName = hostName;
+        return this;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public ProxyConfiguration setPort(String port) {
+        this.port = port;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "ProxyConfiguration{" +
+                "hostName='" + hostName + '\'' +
+                ", port='" + port + '\'' +
+                '}';
+    }
+}

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
@@ -93,6 +93,16 @@ public @interface AzureAuthenticationDefinition {
     ClaimsDefinition claimsDefinition() default @ClaimsDefinition;
 
     /**
+     * Defines the proxy mapping for requests passing through a reverse web
+     * proxy. This field specifies the details of how to handle requests when
+     * going through a proxy.
+     *
+     * @return Proxy mapping details for requests passing through a reverse web
+     * proxy.
+     */
+    ProxyDefinition proxyDefinition() default @ProxyDefinition(hostName = "", port = "");
+
+    /**
      * Optional. The Logout definition defines the logout and RP session
      * management configuration.
      *

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
@@ -80,6 +80,16 @@ public @interface GoogleAuthenticationDefinition {
     ClaimsDefinition claimsDefinition() default @ClaimsDefinition;
 
     /**
+     * Defines the proxy mapping for requests passing through a reverse web
+     * proxy. This field specifies the details of how to handle requests when
+     * going through a proxy.
+     *
+     * @return Proxy mapping details for requests passing through a reverse web
+     * proxy.
+     */
+    ProxyDefinition proxyDefinition() default @ProxyDefinition(hostName = "", port = "");
+
+    /**
      * Optional. The Logout definition defines the logout and RP session
      * management configuration.
      *

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -84,6 +84,16 @@ public @interface OpenIdAuthenticationDefinition {
     ClaimsDefinition claimsDefinition() default @ClaimsDefinition;
 
     /**
+     * Defines the proxy mapping for requests passing through a reverse web
+     * proxy. This field specifies the details of how to handle requests when
+     * going through a proxy.
+     *
+     * @return Proxy mapping details for requests passing through a reverse web
+     * proxy.
+     */
+    ProxyDefinition proxyDefinition() default @ProxyDefinition(hostName = "", port = "");
+
+    /**
      * Optional. The Logout definition defines the logout and RP session
      * management configuration.
      *

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/ProxyDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/ProxyDefinition.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.annotations;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The {@link ProxyDefinition} annotation is used to specify proxy
+ * mapping details within the OpenID Connect client configuration. It provides
+ * configuration for handling requests passing through a reverse web proxy.
+ *
+ * @author jGauravGupta
+ */
+@Retention(RUNTIME)
+public @interface ProxyDefinition {
+
+    /**
+     * Specifies the hostname of the proxied server.
+     *
+     * @return The hostname of the proxied server.
+     */
+    String hostName();
+
+    /**
+     * Specifies the port of the proxied server.
+     *
+     * @return The port of the proxied server.
+     */
+    String port();
+
+    /**
+     * The Microprofile Config key for the proxied server's hostname is
+     * <code>{@value}</code>.
+     */
+    String OPENID_MP_PROXY_HOSTNAME = "payara.security.openid.proxyHostname";
+
+    /**
+     * The Microprofile Config key for the proxied server's port is
+     * <code>{@value}</code>.
+     */
+    String OPENID_MP_PROXY_PORT = "payara.security.openid.proxyPort";
+}


### PR DESCRIPTION
The PR aims to expand the functionality of the OIDC Connector by enabling proxy configuration. This addition is crucial for scenarios where the application interacts with an OpenID Connect provider through a reverse proxy, offering more flexibility in handling requests.

### `@ProxyDefinition` Annotation:

`@ProxyDefinition` serves as a means to specify details regarding proxy mapping within the OpenID Connect client configuration.
It contains attributes to specify the `hostName` and `port` of the proxied server.
Microprofile Config keys (`OPENID_MP_PROXY_HOSTNAME` and `OPENID_MP_PROXY_PORT`) have been added for the `hostname` and `port`, allowing configurable setup through properties.

### Enhancements to `@OpenIdAuthenticationDefinition`:

Integration of proxy-related capabilities within the existing `@OpenIdAuthenticationDefinition`.
Includes a field `proxyDefinition()` within `@OpenIdAuthenticationDefinition` to facilitate the configuration of proxy mapping for requests traversing through reverse web proxies.
This addition allows users to specify proxy details, such as `hostname` and `port`, leveraging the `@ProxyDefinition` annotation.

Utilization of proxy configuration details (`hostName` and `port`) to dynamically define the redirect URL, replacing the `baseURL` placeholder if present.