### PR TITLE
FISH-8260 Evaluate extraParams in OpenID

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.security.connectors</groupId>
         <artifactId>security-connectors-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <groupId>fish.payara.security.connectors</groupId>

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.security.connectors</groupId>
         <artifactId>security-connectors-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <groupId>fish.payara.security.connectors</groupId>

--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <artifactId>security-connectors-parent</artifactId>
         <groupId>fish.payara.security.connectors</groupId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <artifactId>security-connectors-parent</artifactId>
         <groupId>fish.payara.security.connectors</groupId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>security-connectors-parent</artifactId>
         <groupId>fish.payara.security.connectors</groupId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>openid standalone</name>

--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <artifactId>security-connectors-parent</artifactId>
         <groupId>fish.payara.security.connectors</groupId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>openid standalone</name>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.security.connectors</groupId>
         <artifactId>security-connectors-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.8.0</version>
     </parent>
 
     <groupId>fish.payara.security.connectors</groupId>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.security.connectors</groupId>
         <artifactId>security-connectors-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
     </parent>
 
     <groupId>fish.payara.security.connectors</groupId>

--- a/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
@@ -153,7 +153,7 @@ public class AzureDefinitionConverter {
 
             @Override
             public String extraParametersExpression() {
-                return "";
+                return azureDefinition.extraParametersExpression();
             }
 
             @Override

--- a/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 - 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/AzureDefinitionConverter.java
@@ -152,6 +152,11 @@ public class AzureDefinitionConverter {
             }
 
             @Override
+            public String extraParametersExpression() {
+                return "";
+            }
+
+            @Override
             public Class<? extends Annotation> annotationType() {
                 return azureDefinition.annotationType();
             }

--- a/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
@@ -141,7 +141,7 @@ public class GoogleDefinitionConverter {
 
             @Override
             public String extraParametersExpression() {
-                return "";
+                return googleDefinition.extraParametersExpression();
             }
 
             @Override

--- a/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 - 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
+++ b/openid/src/main/java/fish/payara/security/openid/GoogleDefinitionConverter.java
@@ -140,6 +140,11 @@ public class GoogleDefinitionConverter {
             }
 
             @Override
+            public String extraParametersExpression() {
+                return "";
+            }
+
+            @Override
             public Class<? extends Annotation> annotationType() {
                 return googleDefinition.annotationType();
             }

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -66,22 +66,22 @@ public final class OpenIdUtil {
     private OpenIdUtil() {
     }
 
-    public static String readConfiguredValueFromMetadataOrProvider(String metadataValue, JsonObject providerDocument, String openIdConstant, Config provider, String openIdProviderMetadataName) {
+    public static String readConfiguredValueFromMetadataOrProvider(ELProcessor elProcessor, String metadataValue, JsonObject providerDocument, String openIdConstant, Config provider, String openIdProviderMetadataName) {
         String value;
         if (isEmpty(metadataValue) && providerDocument.containsKey(openIdConstant)) {
-            value = getConfiguredValue(String.class, providerDocument.getString(openIdConstant), provider, openIdProviderMetadataName);
+            value = getConfiguredValue(elProcessor, String.class, providerDocument.getString(openIdConstant), provider, openIdProviderMetadataName);
         } else {
-            value = getConfiguredValue(String.class, metadataValue, provider, openIdProviderMetadataName);
+            value = getConfiguredValue(elProcessor, String.class, metadataValue, provider, openIdProviderMetadataName);
         }
         return value;
     }
 
-    public static Set<String> readConfiguredValueFromMetadataOrProvider(String[] metadataValue, JsonObject providerDocument, String openIdConstant, Config provider, String openIdProviderMetadataName) {
+    public static Set<String> readConfiguredValueFromMetadataOrProvider(ELProcessor elProcessor, String[] metadataValue, JsonObject providerDocument, String openIdConstant, Config provider, String openIdProviderMetadataName) {
         String[] valueArr;
         if (metadataValue.length == 0 && providerDocument.containsKey(openIdConstant)) {
-            valueArr = getConfiguredValue(String[].class, getValues(providerDocument, openIdConstant), provider, openIdProviderMetadataName);
+            valueArr = getConfiguredValue(elProcessor, String[].class, getValues(providerDocument, openIdConstant), provider, openIdProviderMetadataName);
         } else {
-            valueArr = getConfiguredValue(String[].class, metadataValue, provider, openIdProviderMetadataName);
+            valueArr = getConfiguredValue(elProcessor, String[].class, metadataValue, provider, openIdProviderMetadataName);
         }
         return new HashSet<>(Arrays.asList(valueArr));
     }
@@ -100,19 +100,31 @@ public final class OpenIdUtil {
         }
     }
 
+    public static ELProcessor createELProcessor() {
+        ELProcessor elProcessor = new ELProcessor();
+        BeanManager beanManager = getBeanManagerForCurrentModule();
+        elProcessor.getELManager().addELResolver(beanManager.getELResolver());
+        return elProcessor;
+    }
+
+    public static <T> T getConfiguredValue(ELProcessor elProcessor, Class<T> type, T value) {
+        if (value instanceof String && isELExpression((String) value)) {
+            return (T) elProcessor.getValue(toRawExpression((String) value), type);
+        }
+        return value;
+    }
+
     public static <T> T getConfiguredValue(Class<T> type, T value, Config provider, String mpConfigKey) {
-        T result = value;
+        ELProcessor elProcessor = createELProcessor();
+        return getConfiguredValue(elProcessor, type, value, provider, mpConfigKey);
+    }
+
+    public static <T> T getConfiguredValue(ELProcessor elProcessor, Class<T> type, T value, Config provider, String mpConfigKey) {
         Optional<T> configResult = provider.getOptionalValue(mpConfigKey, type);
         if (configResult.isPresent()) {
             return configResult.get();
         }
-        if (type == String.class && isELExpression((String) value)) {
-            ELProcessor elProcessor = new ELProcessor();
-            BeanManager beanManager = getBeanManagerForCurrentModule();
-            elProcessor.getELManager().addELResolver(beanManager.getELResolver());
-            result = (T) elProcessor.getValue(toRawExpression((String) result), type);
-        }
-        return result;
+        return getConfiguredValue(elProcessor, type, value);
     }
 
     private static BeanManager getBeanManagerForCurrentModule() {

--- a/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
+++ b/openid/src/main/java/fish/payara/security/openid/OpenIdUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
+++ b/openid/src/main/java/fish/payara/security/openid/controller/ConfigurationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/openid/src/test/java/fish/payara/security/openid/controller/ConfigurationControllerTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/controller/ConfigurationControllerTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.security.openid.controller;
+
+import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
+import fish.payara.security.annotations.OpenIdProviderMetadata;
+import fish.payara.security.openid.domain.OpenIdConfiguration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.el.ELProcessor;
+import javax.json.JsonObject;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Test parsing configuration. Right now, only extraParameters are tested.
+ *
+ * @author Petr Aubrecht
+ */
+@ExtendWith(MockitoExtension.class)
+@RunWith(JUnitPlatform.class)
+public class ConfigurationControllerTest {
+
+    private AutoCloseable closeable;
+
+    @Mock
+    private Config config;
+
+    @Mock
+    private ELProcessor elProcessor;
+
+    @InjectMocks
+    private ConfigurationController controller;
+
+    @Mock
+    private ProviderMetadataContoller providerMetadataContoller;
+
+    @OpenIdAuthenticationDefinition(
+            providerURI = "https://example.com/openid",
+            providerMetadata = @OpenIdProviderMetadata(
+                    issuer = "https://example.com/issuer",
+                    jwksURI = "https://example.com/jwks",
+                    authorizationEndpoint = "https://example.com/auth",
+                    tokenEndpoint = "https://example.com/token",
+                    responseTypesSupported = "code",
+                    idTokenEncryptionAlgValuesSupported = "",
+                    idTokenSigningAlgValuesSupported = ""
+            ),
+            clientId = "XYZ",
+            extraParameters = {"a=1", "b=2", "c=3"}
+    )
+    public static class DefinitionExtraParametersStatic {
+    }
+
+    @OpenIdAuthenticationDefinition(
+            providerURI = "https://example.com/openid",
+            providerMetadata = @OpenIdProviderMetadata(
+                    issuer = "https://example.com/issuer",
+                    jwksURI = "https://example.com/jwks",
+                    authorizationEndpoint = "https://example.com/auth",
+                    tokenEndpoint = "https://example.com/token",
+                    responseTypesSupported = "code",
+                    idTokenEncryptionAlgValuesSupported = "",
+                    idTokenSigningAlgValuesSupported = ""
+            ),
+            clientId = "XYZ",
+            extraParameters = {"a=#{1}", "b=#{2}", "c=#{3}"}
+    )
+    public static class DefinitionExtraParametersValueExpression {
+    }
+
+    @OpenIdAuthenticationDefinition(
+            providerURI = "https://example.com/openid",
+            providerMetadata = @OpenIdProviderMetadata(
+                    issuer = "https://example.com/issuer",
+                    jwksURI = "https://example.com/jwks",
+                    authorizationEndpoint = "https://example.com/auth",
+                    tokenEndpoint = "https://example.com/token",
+                    responseTypesSupported = "code",
+                    idTokenEncryptionAlgValuesSupported = "",
+                    idTokenSigningAlgValuesSupported = ""
+            ),
+            clientId = "XYZ",
+            //securityBean.extraParametersArray returns array of strings in form of "a=1", "b=2", "c=3"
+            extraParametersExpression = "#{securityBean.extraParametersArray}"
+    )
+    public static class DefinitionExtraParametersExpressionArray {
+    }
+
+    @OpenIdAuthenticationDefinition(
+            providerURI = "https://example.com/openid",
+            providerMetadata = @OpenIdProviderMetadata(
+                    issuer = "https://example.com/issuer",
+                    jwksURI = "https://example.com/jwks",
+                    authorizationEndpoint = "https://example.com/auth",
+                    tokenEndpoint = "https://example.com/token",
+                    responseTypesSupported = "code",
+                    idTokenEncryptionAlgValuesSupported = "",
+                    idTokenSigningAlgValuesSupported = ""
+            ),
+            clientId = "XYZ",
+            //securityBean.extraParametersString returns string in format "a=1,b=2,c=3"
+            extraParametersExpression = "#{securityBean.extraParametersString}"
+    )
+    public static class DefinitionExtraParametersExpressionString {
+    }
+
+    @OpenIdAuthenticationDefinition(
+            providerURI = "https://example.com/openid",
+            providerMetadata = @OpenIdProviderMetadata(
+                    issuer = "https://example.com/issuer",
+                    jwksURI = "https://example.com/jwks",
+                    authorizationEndpoint = "https://example.com/auth",
+                    tokenEndpoint = "https://example.com/token",
+                    responseTypesSupported = "code",
+                    idTokenEncryptionAlgValuesSupported = "",
+                    idTokenSigningAlgValuesSupported = ""
+            ),
+            clientId = "XYZ",
+            // it will be overriden by MP, OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION
+            // format is URL parameters, e.g. a=1&b=2
+            extraParameters = {"whatever"}
+    )
+    public static class DefinitionExtraParametersMPOverriden {
+    }
+
+    private static Map<String, List<String>> correctExtraParameters;
+
+    @BeforeAll
+    public static void initTests() {
+        // When moving to Java 11, replace with this:
+        // Map.of("a", List.of("1"), "b", List.of("2"), "c", List.of("3"));
+        correctExtraParameters = new HashMap<>();
+        correctExtraParameters.put("a", Arrays.asList("1"));
+        correctExtraParameters.put("b", Arrays.asList("2"));
+        correctExtraParameters.put("c", Arrays.asList("3"));
+    }
+
+    @BeforeEach
+    public void openMocks() {
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    public void releaseMocks() throws Exception {
+        closeable.close();
+    }
+
+
+    public ConfigurationControllerTest() {
+    }
+
+    /**
+     * Test buildConfig, static extra parameters.
+     */
+    @Test
+    public void testBuildConfigExtraParametersStatic() {
+        when(config.getOptionalValue(anyString(), eq(String.class))).thenReturn(Optional.empty());
+        when(providerMetadataContoller.getDocument(anyString())).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+
+        OpenIdAuthenticationDefinition definition = DefinitionExtraParametersStatic.class.getAnnotation(OpenIdAuthenticationDefinition.class);
+        OpenIdConfiguration configuration = controller.buildConfig(definition, config, elProcessor);
+        assertEquals(correctExtraParameters, configuration.getExtraParameters());
+    }
+
+    /**
+     * Test buildConfig, extra parameters with expressions in values.
+     */
+    @Test
+    public void testBuildConfigExtraParametersValueExpression() {
+        when(config.getOptionalValue(anyString(), eq(String.class))).thenReturn(Optional.empty());
+        when(providerMetadataContoller.getDocument(anyString())).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        when(elProcessor.getValue(eq("1"), any())).thenReturn("1");
+        when(elProcessor.getValue(eq("2"), any())).thenReturn("2");
+        when(elProcessor.getValue(eq("3"), any())).thenReturn("3");
+
+        OpenIdAuthenticationDefinition definition = DefinitionExtraParametersValueExpression.class.getAnnotation(OpenIdAuthenticationDefinition.class);
+        OpenIdConfiguration configuration = controller.buildConfig(definition, config, elProcessor);
+        assertEquals(correctExtraParameters, configuration.getExtraParameters());
+    }
+
+    /**
+     * Test buildConfig, extra parameters using expression, which returns list
+     * of strings.
+     */
+    @Test
+    public void testBuildConfigExtraParametersExpressionArray() {
+        when(config.getOptionalValue(anyString(), eq(String.class))).thenReturn(Optional.empty());
+        when(providerMetadataContoller.getDocument(anyString())).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        when(elProcessor.getValue(any(), any())).thenReturn(null);
+        when(elProcessor.getValue(eq("securityBean.extraParametersArray"), any())).thenReturn(new String[]{"a=1", "b=2", "c=3"});
+        // Testing Mockito
+        assertArrayEquals(new String[]{"a=1", "b=2", "c=3"}, (String[]) elProcessor.getValue("securityBean.extraParametersArray", String.class));
+
+        OpenIdAuthenticationDefinition definition = DefinitionExtraParametersExpressionArray.class.getAnnotation(OpenIdAuthenticationDefinition.class);
+        OpenIdConfiguration configuration = controller.buildConfig(definition, config, elProcessor);
+        assertEquals(correctExtraParameters, configuration.getExtraParameters());
+    }
+
+    /**
+     * Test buildConfig, extra parameters using expression, which returns
+     * strings with comma-separated values.
+     */
+    @Test
+    public void testBuildConfigExtraParametersExpressionString() {
+        when(config.getOptionalValue(anyString(), eq(String.class))).thenReturn(Optional.empty());
+        when(providerMetadataContoller.getDocument(anyString())).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        when(elProcessor.getValue(eq("securityBean.extraParametersString"), any())).thenReturn("a=1,b=2,c=3");
+
+        OpenIdAuthenticationDefinition definition = DefinitionExtraParametersExpressionString.class.getAnnotation(OpenIdAuthenticationDefinition.class);
+        OpenIdConfiguration configuration = controller.buildConfig(definition, config, elProcessor);
+        assertEquals(correctExtraParameters, configuration.getExtraParameters());
+    }
+
+    /**
+     * Test buildConfig, extra parameters using MPConfig,
+     * OpenIdAuthenticationDefinition.OPENID_MP_DISABLE_SCOPE_VALIDATION
+     */
+    @Test
+    public void testBuildConfigExtraParametersViaMPConfig() {
+        when(config.getOptionalValue(anyString(), any())).thenReturn(Optional.empty());
+        when(providerMetadataContoller.getDocument(anyString())).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        //when(elProcessor.getValue(any(), any())).thenReturn(null);
+        when(config.getOptionalValue(eq(OpenIdAuthenticationDefinition.OPENID_MP_EXTRA_PARAMS_RAW), eq(String.class))).thenReturn(Optional.of("a=1&b=2&c=3"));
+
+        OpenIdAuthenticationDefinition definition = DefinitionExtraParametersMPOverriden.class.getAnnotation(OpenIdAuthenticationDefinition.class);
+        OpenIdConfiguration configuration = controller.buildConfig(definition, config, elProcessor);
+        assertEquals(correctExtraParameters, configuration.getExtraParameters());
+    }
+
+    /**
+     * Test of createUrlQuery method, of class ConfigurationController.
+     */
+    @Test
+    public void testCreateUrlQuery() {
+        String[] extraParameters = new String[]{"a=1", "b=2"};
+        String urlParams = ConfigurationController.createUrlQuery(elProcessor, "extraParameters", extraParameters);
+        assertEquals("a=1&b=2", urlParams);
+    }
+}

--- a/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
@@ -60,48 +60,48 @@ public class ConfigurationControllerTest {
     @Test
     public void createUrlNoParameter() {
         assertEquals("",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{}));
     }
 
     @Test
     public void createUrlOneParameter() {
         assertEquals("a=b",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{"a=b"}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"a=b"}));
     }
 
     @Test
     public void createUrlSimpleParameters() {
         assertEquals("a=b&c=d",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{"a=b", "c=d"}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"a=b", "c=d"}));
     }
 
     @Test
     public void createUrlNoValueParameters() {
         assertEquals("a&c=d&e",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{"a", "c=d", "e"}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"a", "c=d", "e"}));
     }
 
     @Test
     public void createUrlWithSpacesParameters() {
         assertEquals("a=b+b&c=++d++&e",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{"a=b b", "c=  d  ", "e="}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"a=b b", "c=  d  ", "e="}));
     }
 
     @Test
     public void createUrlWithoutKeyNameParameters() {
         // these cases are cought by OpenIdExtension anyway, just defensive test:
         Assertions.assertThrows(OpenIdAuthenticationException.class,
-                () -> ConfigurationController.createUrlQuery("extraParameters", new String[]{""}));
+                () -> ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{""}));
         Assertions.assertThrows(OpenIdAuthenticationException.class,
-                () -> ConfigurationController.createUrlQuery("extraParameters", new String[]{"="}));
+                () -> ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"="}));
         Assertions.assertThrows(OpenIdAuthenticationException.class,
-                () -> ConfigurationController.createUrlQuery("extraParameters", new String[]{"=a"}));
+                () -> ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{"=a"}));
     }
 
     @Test
     public void createUrlWithBlankKeyNameParameters() {
         assertEquals("+=+",
-                ConfigurationController.createUrlQuery("extraParameters", new String[]{" = "}));
+                ConfigurationController.createUrlQuery(null, "extraParameters", new String[]{" = "}));
     }
 
     @Test

--- a/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
+++ b/openid/src/test/java/fish/payara/security/openid/domain/ConfigurationControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <groupId>fish.payara.security.connectors</groupId>
     <artifactId>security-connectors-parent</artifactId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
     <packaging>pom</packaging>
     <name>Payara Security Connectors</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <groupId>fish.payara.security.connectors</groupId>
     <artifactId>security-connectors-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <packaging>pom</packaging>
     <name>Payara Security Connectors</name>
 

--- a/security-connectors-api/pom.xml
+++ b/security-connectors-api/pom.xml
@@ -43,12 +43,12 @@
     <parent>
     <artifactId>security-connectors-parent</artifactId>
     <groupId>fish.payara.security.connectors</groupId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
   </parent>
 
     <groupId>fish.payara.security.connectors</groupId>
     <artifactId>security-connectors-api</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <packaging>bundle</packaging>
 
     <name>Payara Security Connnectors API</name>

--- a/security-connectors-api/pom.xml
+++ b/security-connectors-api/pom.xml
@@ -43,12 +43,12 @@
     <parent>
     <artifactId>security-connectors-parent</artifactId>
     <groupId>fish.payara.security.connectors</groupId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
   </parent>
 
     <groupId>fish.payara.security.connectors</groupId>
     <artifactId>security-connectors-api</artifactId>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
     <packaging>bundle</packaging>
 
     <name>Payara Security Connnectors API</name>

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 - 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/AzureAuthenticationDefinition.java
@@ -216,6 +216,14 @@ public @interface AzureAuthenticationDefinition {
     String[] extraParameters() default {};
 
     /**
+     * Allows the extra parameters to be defined as a Jakarta Expression
+     * Language expression. If set, overrides the extraParameters value.
+     *
+     * @return
+     */
+    String extraParametersExpression() default "";
+
+    /**
      * Optional. Sets the connect timeout(in milliseconds) for Remote JWKS
      * retrieval. Value must not be negative and if value is zero then infinite
      * timeout.

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 - 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/GoogleAuthenticationDefinition.java
@@ -203,6 +203,14 @@ public @interface GoogleAuthenticationDefinition {
     String[] extraParameters() default {};
 
     /**
+     * Allows the extra parameters to be defined as a Jakarta Expression
+     * Language expression. If set, overrides the extraParameters value.
+     *
+     * @return
+     */
+    String extraParametersExpression() default "";
+
+    /**
      * Optional. Sets the connect timeout(in milliseconds) for Remote JWKS
      * retrieval. Value must not be negative and if value is zero then infinite
      * timeout.

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 - 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/OpenIdAuthenticationDefinition.java
@@ -210,6 +210,14 @@ public @interface OpenIdAuthenticationDefinition {
     String[] extraParameters() default {};
 
     /**
+     * Allows the extra parameters to be defined as a Jakarta Expression
+     * Language expression. If set, overrides the extraParameters value.
+     *
+     * @return
+     */
+    String extraParametersExpression() default "";
+
+    /**
      * Optional. Sets the connect timeout(in milliseconds) for Remote JWKS
      * retrieval. Value must not be negative and if value is zero then infinite
      * timeout.


### PR DESCRIPTION
Payara's OpenID annotations are now configurable in these ways:

```
extraParameters = {"a=1", "b=2", "c=3"}
extraParameters = {"a=#{1}", "b=#{2}", "c=#{3}"}
//securityBean.extraParametersArray returns array of strings in form of "a=1", "b=2", "c=3"
extraParametersExpression = "#{securityBean.extraParametersArray}"
//securityBean.extraParametersString returns string in format "a=1,b=2,c=3"
extraParametersExpression = "#{securityBean.extraParametersString}"
// MP Config value, overrides everything, backward compatibility, url syntax:
payara.security.openid.extraParams.raw=approval_prompt=force&access_type=offline&param_type=mp_override
```