### PR TITLE
FISH-12985 Deprecate YubiKey from Payara 5

### DIFF
--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/TwoIdentityStoreAuthenticationMechanismDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/TwoIdentityStoreAuthenticationMechanismDefinition.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -53,6 +53,7 @@ import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface TwoIdentityStoreAuthenticationMechanismDefinition {
     
     @Nonbinding

--- a/security-connectors-api/src/main/java/fish/payara/security/annotations/YubikeyIdentityStoreDefinition.java
+++ b/security-connectors-api/src/main/java/fish/payara/security/annotations/YubikeyIdentityStoreDefinition.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- *    Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  * 
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -69,6 +69,7 @@ import java.lang.annotation.Target;
 
 @Retention(value=RetentionPolicy.RUNTIME)
 @Target(value=ElementType.TYPE)
+@Deprecated
 public @interface YubikeyIdentityStoreDefinition {
     
     String YUBICO_API_KEY= "payara.security.yubikey.apikey";


### PR DESCRIPTION
Deprecating unused interfaces as there are no implementations left
implementation was removed back in 2021 in https://github.com/payara/Payara/pull/4808
deprecated in https://github.com/payara/Payara-Enterprise/pull/2754