### PR TITLE
FISH-13413 Add missing POM metadata and explicit dependency versions for OpenID standalone modules

### DIFF
--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -53,6 +53,37 @@
 
     <artifactId>openid-standalone-it</artifactId>
 
+    <name>Payara Security Connectors OpenID Standalone Integration Tests</name>
+    <description>Integration tests for the Payara Security Connectors OpenID standalone artifact.</description>
+    <url>https://github.com/payara/ecosystem-security-connectors</url>
+
+    <licenses>
+        <license>
+            <name>CDDL + GPLv2 with classpath exception</name>
+            <url>https://raw.githubusercontent.com/payara/Payara/master/LICENSE.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>jgauravgupta</id>
+            <name>Gaurav Gupta</name>
+            <organization>Payara</organization>
+            <timezone>GMT+5.5</timezone>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/payara/ecosystem-security-connectors.git</connection>
+        <developerConnection>scm:git:ssh@github.com:payara/ecosystem-security-connectors.git</developerConnection>
+        <url>http://github.com/payara/ecosystem-security-connectors</url>
+    </scm>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -89,17 +120,20 @@
         <dependency>
             <groupId>fish.payara.security.connectors</groupId>
             <artifactId>openid-standalone</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${junit-bom.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
+            <version>${arquillian-bom.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -107,6 +141,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -116,11 +151,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
+            <version>${payara.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
+            <version>${payara.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -131,14 +168,17 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.security.enterprise</groupId>
             <artifactId>jakarta.security.enterprise-api</artifactId>
+            <version>${jakarta.security.enterprise.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <version>${jakartaee.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/openid-standalone/pom.xml
+++ b/openid-standalone/pom.xml
@@ -48,6 +48,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>openid-standalone</artifactId>
+    <name>Payara Security Connectors OpenID Standalone</name>
 
     <licenses>
         <license>


### PR DESCRIPTION
### Motivation
- Component validation reported missing project metadata and dependency versions for the OpenID standalone modules, causing scan/packaging failures. 
- The OpenID standalone module lacked a `<name>` entry and the integration-tests module lacked explicit `name`, `description`, `url`, `licenses`, `developers` and `scm` entries required by consumers and validators. 
- Several dependencies used in `openid-standalone-it` did not declare explicit versions, which caused downstream validation to flag them as missing.

<img width="2150" height="1784" alt="image" src="https://github.com/user-attachments/assets/f31e42ea-9b72-4987-8081-5b841ebb8ee0" />

