### PR TITLE
FISH-13413 Add flatten-maven-plugin to openid-standalone-it

### DIFF
--- a/openid-standalone-it/pom.xml
+++ b/openid-standalone-it/pom.xml
@@ -165,6 +165,29 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                    <pomElements>
+                        <developers>resolve</developers>
+                        <build>remove</build>
+                        <dependencies>remove</dependencies>
+                    </pomElements>
+                    <flattenedPomFilename>target/flattened-pom.xml</flattenedPomFilename>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <mockito-junit-jupiter.version>5.12.0</mockito-junit-jupiter.version>
         <maven-shade-plugin.version>3.5.3</maven-shade-plugin.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
-        <payara.version>7.2025.1.Alpha1-SNAPSHOT</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <arquillian-bom.version>1.9.3.Final</arquillian-bom.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <payara-micro-maven-plugin.version>2.3</payara-micro-maven-plugin.version>


### PR DESCRIPTION
Inline parent metadata (name, url, licenses, scm, developers) and resolve BOM-managed dependency versions into the published POM so Sonatype Central validation passes for the openid-standalone-it artifact.